### PR TITLE
Fix AI skill assistant: auto-apply suggestions instead of requiring b…

### DIFF
--- a/src/main/java/com/dtech/kitecon/web/copilot/CopilotSkillController.java
+++ b/src/main/java/com/dtech/kitecon/web/copilot/CopilotSkillController.java
@@ -118,17 +118,20 @@ public class CopilotSkillController {
                   6. ambiguityQuestions — targeted questions to ask the expert when unsure
                   7. crossVerificationRules — what must be true on OTHER timeframes
 
-                When the user describes what they want, provide specific text they can paste into the field(s).
-                Return ONLY a JSON object:
+                When the user describes what they want, write detailed, specific content for the relevant field(s).
+                IMPORTANT: Your suggestedFields will be AUTOMATICALLY applied to the skill fields immediately.
+                So in your reply, say "I've written/updated [field names] for you" — never say "please click" or "paste this".
+                Always populate suggestedFields with the actual content whenever you write any field text.
+                Return ONLY a JSON object with no markdown fences:
                 {
-                  "reply": "your conversational response",
+                  "reply": "brief confirmation of what fields you wrote and why",
                   "suggestedFields": {
-                    "fieldName": "suggested text"
+                    "fieldName": "full detailed text for this field"
                   }
                 }
                 Field names must exactly match: identificationRules, stageDetection, entryRules,
                 indicatorRules, invalidationRules, ambiguityQuestions, crossVerificationRules.
-                suggestedFields may be empty if no field suggestion is appropriate.
+                suggestedFields may be empty only if the user is asking a question, not requesting content.
                 """;
 
         StringBuilder userMessage = new StringBuilder();

--- a/ui/chart-draw-app/src/tradingview/SkillBuilderPage.tsx
+++ b/ui/chart-draw-app/src/tradingview/SkillBuilderPage.tsx
@@ -46,7 +46,7 @@ const EMPTY_SKILL: Partial<CopilotSkill> = {
 type NavSelection = { type: 'orchestrator' } | { type: 'skill'; id: number | 'new' };
 type PageMode = 'view' | 'edit';
 
-interface ChatMessage { role: 'user' | 'assistant'; content: string; suggestedFields?: Record<string, string> }
+interface ChatMessage { role: 'user' | 'assistant'; content: string; appliedFields?: string[] }
 interface AttachedFile { name: string; content: string }
 
 // ─── Prompt compile / decompile ───────────────────────────────────────────────
@@ -307,9 +307,17 @@ export default function SkillBuilderPage() {
     setChatLoading(true);
     try {
       const res: AiAssistResponse = await aiAssistSkill(fullMsg, form);
+      const hasFields = res.suggestedFields && Object.keys(res.suggestedFields).length > 0;
+
+      // Auto-apply fields immediately — no manual button needed
+      if (hasFields) {
+        setForm(prev => ({ ...prev, ...res.suggestedFields }));
+        if (mode === 'view') setMode('edit');
+      }
+
       setChat(prev => [...prev, {
         role: 'assistant', content: res.reply,
-        suggestedFields: res.suggestedFields && Object.keys(res.suggestedFields).length > 0 ? res.suggestedFields : undefined,
+        appliedFields: hasFields ? Object.keys(res.suggestedFields!) : undefined,
       }]);
     } catch (e) {
       setChat(prev => [...prev, { role: 'assistant', content: `Error: ${e}` }]);
@@ -319,7 +327,6 @@ export default function SkillBuilderPage() {
   const applyFields = (fields: Record<string, string>) => {
     setForm(prev => ({ ...prev, ...fields }));
     if (mode === 'view') setMode('edit');
-    setSuccess('AI suggestions applied — review and save when ready.');
   };
 
   // ─── Render ─────────────────────────────────────────────────────────────────
@@ -549,10 +556,13 @@ export default function SkillBuilderPage() {
                         }}>
                           {msg.content}
                         </div>
-                        {msg.suggestedFields && (
-                          <button onClick={() => applyFields(msg.suggestedFields!)} style={{ marginTop: 4, fontSize: 11, padding: '3px 10px', background: '#43a047', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer' }}>
-                            ✓ Apply {Object.keys(msg.suggestedFields).length} suggestion(s) to fields
-                          </button>
+                        {msg.appliedFields && (
+                          <div style={{ marginTop: 4, fontSize: 11, color: '#43a047', display: 'flex', flexWrap: 'wrap', gap: 4 }}>
+                            <span style={{ fontWeight: 700 }}>✓ Applied:</span>
+                            {msg.appliedFields.map(f => (
+                              <span key={f} style={{ background: '#e8f5e9', color: '#2e7d32', padding: '1px 6px', borderRadius: 8 }}>{f}</span>
+                            ))}
+                          </div>
                         )}
                       </div>
                     ))}


### PR DESCRIPTION
…utton click

- Backend: update system prompt to tell AI its suggestedFields are applied automatically, so it uses accurate language ("I've written X for you") and reliably populates suggestedFields whenever it writes field content
- Frontend: auto-apply suggestedFields to form immediately on receipt instead of showing a manual "Apply" button that users didn't notice
- Show applied field names as green tags in chat history so user can see what changed without having to scroll the right panel