### PR TITLE
bugfix_001: ML filter at entry time, Kite OAuth fix, screener improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,14 @@ aws cloudfront create-invalidation --distribution-id E3GNIWHAP6FDTM --paths "/in
 
 Never commit directly to `master`. If the current branch is `master`, stop and ask the user whether to create a new branch before making any changes.
 
+## PR and Issue Policy — No Code Merged Without a PR + GitHub Issue
+
+Every code change merged to `master` must have:
+1. A **GitHub issue** describing what changed and why (bug, feature, or fix)
+2. A **Pull Request** referencing that issue — never merge directly, always go through a PR
+
+Create the issue first, then the PR. Reference the issue in the PR body (e.g. `Closes #33`).
+
 ## New Pages — Add to Dashboard
 
 Any new top-level page that doesn't belong under an existing parent section **must** be linked from the Dashboard (`src/components/Dashboard.tsx`). This ensures all features are discoverable from the home screen.

--- a/src/main/java/com/dtech/kitecon/kite/service/UserKiteConfigService.java
+++ b/src/main/java/com/dtech/kitecon/kite/service/UserKiteConfigService.java
@@ -58,9 +58,19 @@ public class UserKiteConfigService {
     }
 
     public String getLoginUrl(Long id) {
+        log.info("[KiteLogin] looking up UserKiteConfig id={}", id);
         UserKiteConfig config = repository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Config not found: " + id));
-        return "https://kite.trade/connect/login?api_key=" + config.getApiKey() + "&v=3";
+                .orElseThrow(() -> {
+                    log.error("[KiteLogin] UserKiteConfig not found for id={}", id);
+                    return new IllegalArgumentException("Config not found: " + id);
+                });
+        log.info("[KiteLogin] found config id={} label='{}' apiKey={} kiteUserId={}",
+                id, config.getLabel(),
+                config.getApiKey() != null ? config.getApiKey().substring(0, Math.min(4, config.getApiKey().length())) + "***" : "NULL",
+                config.getKiteUserId());
+        String url = "https://kite.trade/connect/login?api_key=" + config.getApiKey() + "&v=3";
+        log.info("[KiteLogin] built login URL: {}", url);
+        return url;
     }
 
     @Transactional

--- a/src/main/java/com/dtech/kitecon/kite/web/UserKiteConfigController.java
+++ b/src/main/java/com/dtech/kitecon/kite/web/UserKiteConfigController.java
@@ -83,6 +83,21 @@ public class UserKiteConfigController {
         return new RedirectView("/admin/kite-config");
     }
 
+    @PostMapping("/api/admin/kite-configs/{id}/process-token")
+    public ResponseEntity<?> processToken(
+            @PathVariable Long id,
+            @RequestParam("request_token") String requestToken) {
+        try {
+            service.processCallback(id, requestToken);
+            tickerService.init();
+            log.info("Kite config {} authenticated via process-token", id);
+            return ResponseEntity.ok(Map.of("status", "ok", "connected", true));
+        } catch (Exception e) {
+            log.error("process-token failed for config {}: {}", id, e.getMessage(), e);
+            return ResponseEntity.status(500).body(Map.of("status", "error", "message", e.getMessage()));
+        }
+    }
+
     // ── Request DTOs ──
 
     @lombok.Data

--- a/src/main/java/com/dtech/kitecon/kite/web/UserKiteConfigController.java
+++ b/src/main/java/com/dtech/kitecon/kite/web/UserKiteConfigController.java
@@ -56,8 +56,15 @@ public class UserKiteConfigController {
      */
     @GetMapping("/api/admin/kite-configs/{id}/connect")
     public RedirectView connect(@PathVariable Long id) {
-        String loginUrl = service.getLoginUrl(id);
-        return new RedirectView(loginUrl);
+        log.info("[KiteLogin] connect called for config id={}", id);
+        try {
+            String loginUrl = service.getLoginUrl(id);
+            log.info("[KiteLogin] redirecting to Kite URL: {}", loginUrl);
+            return new RedirectView(loginUrl);
+        } catch (Exception e) {
+            log.error("[KiteLogin] failed to build login URL for id={}: {}", id, e.getMessage(), e);
+            throw e;
+        }
     }
 
     // ── OAuth callback (no JWT — redirected from Kite servers) ──

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
@@ -159,7 +159,8 @@ public class PatternComboScannerService {
                 .notes("Auto-scan: rsiP1=" + pattern.getRsiAtP1() + " rsiP2=" + pattern.getRsiAtP2())
                 .build();
 
-        // ML filter — score the pattern before persisting
+        // ML filter — score the pattern and store for reference, but do NOT gate here.
+        // Filtering happens at entry time (TradeEntryHandler) when the pattern has fully formed.
         double prob = tradeFilterClient.score(
                 pattern, pattern.getPatternType(),
                 0.0, 0.0, 0.0,   // dailyRsi, dailyAdx, dailyAdxEma — TODO: wire from PatternScanService
@@ -170,11 +171,6 @@ public class PatternComboScannerService {
                 0.0, 0.0,         // macdDaily, macdSignalDaily
                 0.0, 0.0          // bbWidthDaily, bbPctBDaily
         );
-        if (prob < filterThreshold) {
-            log.debug("[Scanner] ML filter rejected {} {} prob={} < threshold={}",
-                    symbol, pattern.getPatternType(), prob, filterThreshold);
-            return SignalCreationResult.mlFiltered();
-        }
         signal.setMlScore(BigDecimal.valueOf(prob).setScale(4, RoundingMode.HALF_UP));
 
         signal = tradeSignalRepository.save(signal);

--- a/src/main/java/com/dtech/kitecon/trade/service/TradeEntryHandler.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/TradeEntryHandler.java
@@ -36,6 +36,9 @@ import java.time.Instant;
 @RequiredArgsConstructor
 public class TradeEntryHandler {
 
+    @Value("${trade.filter.threshold:0.82}")
+    private double mlFilterThreshold;
+
     @Value("${trade.monitor.notional:1000000}")
     private long notionalPerLot;
 
@@ -67,6 +70,16 @@ public class TradeEntryHandler {
         }
 
         boolean entryTriggered = isEntryTriggered(signal, ltp);
+
+        if (entryTriggered && !passesMlFilter(signal)) {
+            signal.setStatus(TradeStatus.EXPIRED);
+            signalRepository.save(signal);
+            writeLog(signal, ltp, null, MonitorAction.SIGNAL_EXPIRED,
+                    "ML filter rejected at entry: score=" + signal.getMlScore() + " threshold=" + mlFilterThreshold, dryRun);
+            log.info("[EntryHandler] Signal {} {} ML-filtered at entry — score={} threshold={}",
+                    signal.getId(), signal.getSymbol(), signal.getMlScore(), mlFilterThreshold);
+            return;
+        }
 
         if (!entryTriggered) {
             String msg = String.format("Watching entry: LTP=%.4f entry=%.4f SL=%.4f T=%.4f",
@@ -120,6 +133,11 @@ public class TradeEntryHandler {
         //     writeLog(signal, fillPrice, null, MonitorAction.ENTRY_ORDER_PLACED, "Entry filled at " + fillPrice, dryRun);
         // }
         log.info("[EntryHandler] checkFill for signal {} — live order status check not yet implemented", signal.getId());
+    }
+
+    private boolean passesMlFilter(TradeSignal signal) {
+        if (signal.getMlScore() == null) return true; // no score — let it through
+        return signal.getMlScore().doubleValue() >= mlFilterThreshold;
     }
 
     private boolean isEntryTriggered(TradeSignal signal, BigDecimal ltp) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -132,6 +132,7 @@ trade.monitor.margin=300000
 # Default entry window validity in hours (signal expires if entry not triggered)
 trade.monitor.entry.validity.hours=4
 logging.level.com.dtech.kitecon.trade=INFO
+logging.level.com.dtech.kitecon.kite=INFO
 
 # Trading portfolio and scanner config
 trade.portfolio.value=500000

--- a/ui/chart-draw-app/src/components/KiteCallback.tsx
+++ b/ui/chart-draw-app/src/components/KiteCallback.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { useParams, useSearchParams, useNavigate } from "react-router-dom";
+import { getApiUrl } from "../config/api";
+import { withAuth } from "../utils/apiHelper";
+
+/**
+ * Handles the Kite OAuth callback when Kite redirects to /kite-callback/config/:configId
+ * Extracts request_token, calls backend process-token API, then navigates to admin page.
+ */
+export default function KiteCallback() {
+  const { configId } = useParams<{ configId: string }>();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const processToken = async () => {
+      const requestToken = searchParams.get("request_token");
+      const status = searchParams.get("status");
+
+      if (status !== "success") {
+        setError("Kite authentication failed. Please try again.");
+        return;
+      }
+
+      if (!requestToken) {
+        setError("Request token not found in callback URL.");
+        return;
+      }
+
+      try {
+        const url = getApiUrl(`/api/admin/kite-configs/${configId}/process-token?request_token=${requestToken}`).toString();
+        console.log("[KiteCallback] calling process-token:", url);
+        const res = await fetch(url, { ...withAuth(), method: "POST" });
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.message || `Server error ${res.status}`);
+        }
+        console.log("[KiteCallback] success, navigating to /admin/kite-config");
+        navigate("/admin/kite-config", { replace: true });
+      } catch (err) {
+        console.error("[KiteCallback] error:", err);
+        setError(err instanceof Error ? err.message : "Authentication failed.");
+      }
+    };
+
+    processToken();
+  }, [configId, searchParams, navigate]);
+
+  if (error) {
+    return (
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: "100vh", flexDirection: "column", gap: "16px" }}>
+        <div style={{ color: "#d32f2f", fontSize: "18px", fontWeight: "bold" }}>Authentication Error</div>
+        <div style={{ fontSize: "14px", color: "#666" }}>{error}</div>
+        <button
+          onClick={() => window.location.href = "/kite-login"}
+          style={{ padding: "10px 20px", borderRadius: "6px", border: "1px solid #1976d2", background: "#1976d2", color: "#fff", cursor: "pointer", fontSize: "14px", fontWeight: "600" }}
+        >
+          Try Again
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: "100vh", flexDirection: "column", gap: "16px" }}>
+      <div>Processing Kite authentication...</div>
+      <div style={{ fontSize: "14px", color: "#666" }}>Please wait while we complete the setup.</div>
+    </div>
+  );
+}

--- a/ui/chart-draw-app/src/components/KiteLogin.tsx
+++ b/ui/chart-draw-app/src/components/KiteLogin.tsx
@@ -9,7 +9,8 @@ import {withAuth} from "../utils/apiHelper";
 export default function KiteLogin() {
   useEffect(() => {
     // Redirect to backend endpoint which will redirect to Kite
-    const kiteLoginUrl = getApiUrl("/api/admin/kite-configs/1/connect");
+    const kiteLoginUrl = getApiUrl("/api/admin/kite-configs/1/connect").toString();
+    console.log("[KiteLogin] navigating to:", kiteLoginUrl);
     window.location.href = kiteLoginUrl;
   }, []);
 

--- a/ui/chart-draw-app/src/components/KiteSuccess.tsx
+++ b/ui/chart-draw-app/src/components/KiteSuccess.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
-import { apiFetch } from "../config/api";
-import { withAuth } from "../utils/apiHelper";
+import { useSearchParams } from "react-router-dom";
+import { getApiUrl } from "../config/api";
 
 /**
  * Component to handle Kite callback after successful authentication
@@ -9,7 +8,6 @@ import { withAuth } from "../utils/apiHelper";
  */
 export default function KiteSuccess() {
   const [searchParams] = useSearchParams();
-  const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -33,15 +31,8 @@ export default function KiteSuccess() {
           return;
         }
 
-        // Send request_token to backend /app endpoint
-        const response = await apiFetch(`/update-token?request_token=${requestToken}`, withAuth());
-
-        if (!response.ok) {
-          const errorText = await response.text();
-          throw new Error(errorText || `Failed to initialize: ${response.status}`);
-        }
-
-        navigate("/dashboard");
+        // Navigate to backend callback — it processes the token, saves to UserKiteConfig, and redirects to /admin/kite-config
+        window.location.href = getApiUrl(`/kite-callback/config/1?request_token=${requestToken}`).toString();
 
       } catch (err) {
         console.error("Kite callback error:", err);
@@ -90,7 +81,7 @@ export default function KiteSuccess() {
         </div>
         <div style={{ fontSize: "14px", color: "#666" }}>{error}</div>
         <button
-          onClick={() => navigate("/kite-login")}
+          onClick={() => window.location.href = "/kite-login"}
           style={{
             padding: "10px 20px",
             borderRadius: "6px",

--- a/ui/chart-draw-app/src/main.tsx
+++ b/ui/chart-draw-app/src/main.tsx
@@ -15,6 +15,7 @@ import PromptBuilderPage from "./tradingview/PromptBuilderPage";
 
 import KiteLogin from "./components/KiteLogin";
 import KiteSuccess from "./components/KiteSuccess";
+import KiteCallback from "./components/KiteCallback";
 
 // Get Google OAuth Client ID from environment variable
 // Set this in .env file: VITE_GOOGLE_OAUTH_CLIENT_ID=your_client_id_here
@@ -69,6 +70,7 @@ root.render(
         <Route path="/login" element={<Login />} />
         <Route path="/kite-login" element={<KiteLogin />} />
         <Route path="/kite-success" element={<KiteSuccess />} />
+        <Route path="/kite-callback/config/:configId" element={<KiteCallback />} />
 
         {/* Protected routes */}
         <Route


### PR DESCRIPTION
## Summary

- Closes #32 — ML filter moved from scan time to entry time so forming patterns aren't prematurely rejected
- Closes #33 — Kite OAuth callback fixed; tokens now saved to correct table (`UserKiteConfig`)
- Fix: FNO seeder excludes index futures (BANKNIFTY, NIFTY etc.) using NSE equity cross-validation
- Fix: Seeder inserts symbols with `enabled=true` by default
- Fix: Screener correctly distinguishes `ML_FILTERED` from `DUPLICATE` in run results
- Fix: Pattern recency filter — only keep patterns where keyLevelTime == latest ZigZag pivot
- Add: `POST /api/trade-signals/expire-stale` endpoint for cleaning up stale WATCHING_ENTRY signals
- Docs: CLAUDE.md guidelines — never work on master, new pages on dashboard, PR+issue required for merges

## Test plan
- [ ] Run screener — verify no Torrant Pharma / triangle patterns are filtered at scan time
- [ ] Kite login: click Connect → OAuth → verify "connected" shows on admin page and historical data loads
- [ ] Seeder: Clear All + re-seed → verify symbols inserted with `enabled=true`
- [ ] Screener run results: verify FILTERED rows show "ML Filtered" not "Duplicate"

🤖 Generated with [Claude Code](https://claude.com/claude-code)