### PR TITLE
fix: prevent connection pool exhaustion from concurrent scanner runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,13 +43,20 @@ aws cloudfront create-invalidation --distribution-id E3GNIWHAP6FDTM --paths "/in
 
 Never commit directly to `master`. If the current branch is `master`, stop and ask the user whether to create a new branch before making any changes.
 
-## PR and Issue Policy — No Code Merged Without a PR + GitHub Issue
+## Commit Workflow — Branch → Issue → PR → Merge
 
-Every code change merged to `master` must have:
-1. A **GitHub issue** describing what changed and why (bug, feature, or fix)
-2. A **Pull Request** referencing that issue — never merge directly, always go through a PR
+Before committing any code change, follow this workflow:
 
-Create the issue first, then the PR. Reference the issue in the PR body (e.g. `Closes #33`).
+1. **Ask the user**: is this a bugfix or a feature?
+   - Bugfix → branch name: `bugfix/<short-description>` (e.g. `bugfix/connection-pool-exhaustion`)
+   - Feature → branch name: `feature/<short-description>` (e.g. `feature/pattern-screener-ui`)
+2. **Create a new branch** from `master` with the appropriate name
+3. **Create a GitHub issue** describing what changed and why
+4. **Commit** the changes referencing the issue
+5. **Push** the branch and **create a PR** that closes the issue (e.g. `Closes #34`)
+6. **Merge** the PR into master
+
+Never skip any step. Never commit directly to `master`.
 
 ## New Pages — Add to Dashboard
 

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
@@ -17,6 +17,7 @@ import java.math.RoundingMode;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 @Service
 @Slf4j
@@ -40,14 +41,24 @@ public class PatternComboScannerService {
     @Value("${trade.scanner.confirm.tf:15m}")
     private String confirmTfStr;
 
+    private final AtomicBoolean scanRunning = new AtomicBoolean(false);
+
     @Scheduled(cron = "0 0/15 9-15 * * MON-FRI", zone = "Asia/Kolkata")
     public void scheduledScan() {
         if (!kiteTickerService.isMarketLive()) {
             log.info("[PatternScanner] Skipping scan — no recent ticks (trading holiday or pre-market)");
             return;
         }
-        int count = scanAndCreateSignals();
-        log.info("[PatternScanner] Scheduled scan completed: {} new signals created", count);
+        if (!scanRunning.compareAndSet(false, true)) {
+            log.warn("[PatternScanner] Previous scan still running — skipping this tick");
+            return;
+        }
+        try {
+            int count = scanAndCreateSignals();
+            log.info("[PatternScanner] Scheduled scan completed: {} new signals created", count);
+        } finally {
+            scanRunning.set(false);
+        }
     }
 
     public int scanAndCreateSignals() {

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternScreenerRunRepository.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternScreenerRunRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 @Repository
 public interface PatternScreenerRunRepository extends JpaRepository<PatternScreenerRun, Long> {
     List<PatternScreenerRun> findTop10ByScreenerIdOrderByStartedAtDesc(Long screenerId);
+    boolean existsByScreenerIdAndStatus(Long screenerId, String status);
 }

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternScreenerService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternScreenerService.java
@@ -63,7 +63,7 @@ public class PatternScreenerService {
         screenerRepository.deleteById(id);
     }
 
-    @Async
+    @Async("scanExecutor")
     public void triggerAsync(Long screenerId) {
         PatternScreener screener = screenerRepository.findById(screenerId).orElse(null);
         if (screener == null) return;
@@ -71,6 +71,11 @@ public class PatternScreenerService {
     }
 
     public PatternScreenerRun runScreener(PatternScreener screener) {
+        if (runRepository.existsByScreenerIdAndStatus(screener.getId(), "RUNNING")) {
+            log.warn("[PatternScreener] Screener {} '{}' is already running — skipping overlap", screener.getId(), screener.getName());
+            return runRepository.findTop10ByScreenerIdOrderByStartedAtDesc(screener.getId())
+                    .stream().findFirst().orElse(null);
+        }
         List<TradingSegment> segs = Arrays.stream(screener.getSegments().split(","))
                 .map(String::trim).map(String::toUpperCase)
                 .map(TradingSegment::valueOf)


### PR DESCRIPTION
## Summary

- Closes #35 — HikariPool-1 exhausted (total=30, active=30) crashing the app
- Bind `triggerAsync` to `scanExecutor` (max 5 threads) instead of unbounded default executor
- Add overlap guard in `runScreener()` — skips if screener already has a RUNNING run
- Add `AtomicBoolean` lock in `scheduledScan()` — skips tick if previous scan still running
- Add commit workflow guideline to CLAUDE.md

## Test plan
- [ ] Trigger screener manually twice in quick succession — second should log "already running — skipping overlap"
- [ ] Confirm `scheduledScan` logs "Previous scan still running — skipping this tick" if run takes > 15 min
- [ ] Verify no HikariPool exhaustion in logs under normal load

🤖 Generated with [Claude Code](https://claude.com/claude-code)