### PR TITLE
feat: wire real indicator values into ML trade filter scoring

### DIFF
--- a/src/main/java/com/dtech/kitecon/backtest/PatternComboBacktestService.java
+++ b/src/main/java/com/dtech/kitecon/backtest/PatternComboBacktestService.java
@@ -2432,7 +2432,7 @@ public class PatternComboBacktestService {
         }
     }
 
-    private DailyIndicators computeDailyIndicators(BarSeries dailySeries) {
+    public DailyIndicators computeDailyIndicators(BarSeries dailySeries) {
         if (dailySeries == null || dailySeries.isEmpty()) {
             return new DailyIndicators(new TreeMap<>(), new TreeMap<>(), new TreeMap<>(), new TreeMap<>(), new TreeMap<>(), new TreeMap<>(), new TreeMap<>(), new TreeMap<>(), new TreeMap<>());
         }
@@ -2573,7 +2573,7 @@ public class PatternComboBacktestService {
         }
     }
 
-    private record DailyIndicators(
+    public record DailyIndicators(
             TreeMap<Instant, Double> macdHistMap,
             TreeMap<Instant, Double> rsiMap,
             TreeMap<Instant, Double> stochRsiKMap,
@@ -2584,39 +2584,39 @@ public class PatternComboBacktestService {
             TreeMap<Instant, Double> bbWidthMap,
             TreeMap<Instant, Double> bbPctBMap) {
 
-        double macdHistAtTs(Instant ts) {
+        public double macdHistAtTs(Instant ts) {
             return floorValue(macdHistMap, ts);
         }
 
-        double rsiAtTs(Instant ts) {
+        public double rsiAtTs(Instant ts) {
             return floorValue(rsiMap, ts);
         }
 
-        double stochRsiKAtTs(Instant ts) {
+        public double stochRsiKAtTs(Instant ts) {
             return floorValue(stochRsiKMap, ts);
         }
 
-        double adxAtTs(Instant ts) {
+        public double adxAtTs(Instant ts) {
             return floorValue(adxMap, ts);
         }
 
-        double adxEmaAtTs(Instant ts) {
+        public double adxEmaAtTs(Instant ts) {
             return floorValue(adxEmaMap, ts);
         }
 
-        double macdLineAtTs(Instant ts) {
+        public double macdLineAtTs(Instant ts) {
             return floorValue(macdLineMap, ts);
         }
 
-        double macdSignalAtTs(Instant ts) {
+        public double macdSignalAtTs(Instant ts) {
             return floorValue(macdSignalMap, ts);
         }
 
-        double bbWidthAtTs(Instant ts) {
+        public double bbWidthAtTs(Instant ts) {
             return floorValue(bbWidthMap, ts);
         }
 
-        double bbPctBAtTs(Instant ts) {
+        public double bbPctBAtTs(Instant ts) {
             return floorValue(bbPctBMap, ts);
         }
 

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
@@ -174,13 +174,13 @@ public class PatternComboScannerService {
         // Filtering happens at entry time (TradeEntryHandler) when the pattern has fully formed.
         double prob = tradeFilterClient.score(
                 pattern, pattern.getPatternType(),
-                0.0, 0.0, 0.0,   // dailyRsi, dailyAdx, dailyAdxEma — TODO: wire from PatternScanService
-                0.0, 0.0,         // adxWatching, adxWatchingEma
-                0.0, 0.0,         // adxConfirm, adxConfirmEma
-                0.0, 0.0,         // macdWatching, macdSignalWatching
-                0.0, 0.0,         // bbWidthWatching, bbPctBWatching
-                0.0, 0.0,         // macdDaily, macdSignalDaily
-                0.0, 0.0          // bbWidthDaily, bbPctBDaily
+                pattern.getDailyRsi(), pattern.getDailyAdx(), pattern.getDailyAdxEma(),
+                pattern.getAdxWatching(), pattern.getAdxWatchingEma(),
+                pattern.getAdxConfirm(), pattern.getAdxConfirmEma(),
+                pattern.getMacdWatching(), pattern.getMacdSignalWatching(),
+                pattern.getBbWidthWatching(), pattern.getBbPctBWatching(),
+                pattern.getMacdDaily(), pattern.getMacdSignalDaily(),
+                pattern.getBbWidthDaily(), pattern.getBbPctBDaily()
         );
         signal.setMlScore(BigDecimal.valueOf(prob).setScale(4, RoundingMode.HALF_UP));
 

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternDto.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternDto.java
@@ -21,4 +21,26 @@ public class PatternDto {
     Instant p0Time;           // first top/bottom
     Instant p1Time;           // neckline
     // p2Time = keyLevelTime (second top/bottom)
+
+    // Watching TF indicators (at keyLevelTime)
+    double macdHistAtP1;
+    double macdHistAtP2;
+    double stochRsiK;
+    double adxWatching;
+    double adxWatchingEma;
+    double macdWatching;
+    double macdSignalWatching;
+    double bbWidthWatching;
+    double bbPctBWatching;
+    // Confirm TF indicators (at keyLevelTime)
+    double adxConfirm;
+    double adxConfirmEma;
+    // Daily TF indicators (at keyLevelTime)
+    double dailyRsi;
+    double dailyAdx;
+    double dailyAdxEma;
+    double macdDaily;
+    double macdSignalDaily;
+    double bbWidthDaily;
+    double bbPctBDaily;
 }

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternScanService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternScanService.java
@@ -3,6 +3,7 @@ package com.dtech.kitecon.patternscanner;
 import com.dtech.algo.series.Interval;
 import com.dtech.kitecon.backtest.DetectedPattern;
 import com.dtech.kitecon.backtest.PatternComboBacktestService;
+import com.dtech.kitecon.backtest.PatternComboBacktestService.DailyIndicators;
 import com.dtech.kitecon.repository.InstrumentRepository;
 import com.dtech.kitecon.data.Instrument;
 import com.dtech.chartpattern.zigzag.ZigZagPoint;
@@ -96,6 +97,16 @@ public class PatternScanService {
             watchingPatterns.removeIf(p -> !latestPivotTime.equals(p.getKeyLevelTime()));
         }
 
+        // Load daily and confirm series for indicator computation
+        BarSeries seriesDaily = null;
+        try { seriesDaily = zigZagService.getBarSeries(symbol, instrument, Interval.Day); } catch (Exception ignored) {}
+        BarSeries seriesC = null;
+        try { seriesC = zigZagService.getBarSeries(symbol, instrument, confirmTf); } catch (Exception ignored) {}
+
+        DailyIndicators dailyInd    = patternComboBacktestService.computeDailyIndicators(seriesDaily);
+        DailyIndicators watchingInd = patternComboBacktestService.computeDailyIndicators(seriesW);
+        DailyIndicators confirmInd  = patternComboBacktestService.computeDailyIndicators(seriesC);
+
         // Build pattern DTOs
         List<PatternDto> patternDtos = watchingPatterns.stream().map(p -> PatternDto.builder()
                 .patternType(p.getPatternType())
@@ -109,6 +120,24 @@ public class PatternScanService {
                 .rsiAtP2(p.getRsiAtP2())
                 .p0Time(p.getPivotBTime())
                 .p1Time(p.getPivotDTime())
+                .macdHistAtP1(p.getMacdHistAtP1())
+                .macdHistAtP2(p.getMacdHistAtP2())
+                .stochRsiK(p.getStochRsiK())
+                .adxWatching(watchingInd.adxAtTs(p.getKeyLevelTime()))
+                .adxWatchingEma(watchingInd.adxEmaAtTs(p.getKeyLevelTime()))
+                .macdWatching(watchingInd.macdLineAtTs(p.getKeyLevelTime()))
+                .macdSignalWatching(watchingInd.macdSignalAtTs(p.getKeyLevelTime()))
+                .bbWidthWatching(watchingInd.bbWidthAtTs(p.getKeyLevelTime()))
+                .bbPctBWatching(watchingInd.bbPctBAtTs(p.getKeyLevelTime()))
+                .adxConfirm(confirmInd.adxAtTs(p.getKeyLevelTime()))
+                .adxConfirmEma(confirmInd.adxEmaAtTs(p.getKeyLevelTime()))
+                .dailyRsi(dailyInd.rsiAtTs(p.getKeyLevelTime()))
+                .dailyAdx(dailyInd.adxAtTs(p.getKeyLevelTime()))
+                .dailyAdxEma(dailyInd.adxEmaAtTs(p.getKeyLevelTime()))
+                .macdDaily(dailyInd.macdLineAtTs(p.getKeyLevelTime()))
+                .macdSignalDaily(dailyInd.macdSignalAtTs(p.getKeyLevelTime()))
+                .bbWidthDaily(dailyInd.bbWidthAtTs(p.getKeyLevelTime()))
+                .bbPctBDaily(dailyInd.bbPctBAtTs(p.getKeyLevelTime()))
                 .build()).toList();
 
         // Build overlays for watching TF

--- a/src/main/java/com/dtech/kitecon/patternscanner/TradeFilterClient.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/TradeFilterClient.java
@@ -45,9 +45,9 @@ public class TradeFilterClient {
             payload.put("rr_watching",            pattern.getRrRatio());
             payload.put("rsi_at_p1",              pattern.getRsiAtP1());
             payload.put("rsi_at_p2",              pattern.getRsiAtP2());
-            payload.put("macd_hist_at_p1",        0.0);
-            payload.put("macd_hist_at_p2",        0.0);
-            payload.put("stoch_rsi_k_15m",        0.0);
+            payload.put("macd_hist_at_p1",        pattern.getMacdHistAtP1());
+            payload.put("macd_hist_at_p2",        pattern.getMacdHistAtP2());
+            payload.put("stoch_rsi_k_15m",        pattern.getStochRsiK());
             payload.put("daily_rsi",              dailyRsi);
             payload.put("watching_pattern_height",pattern.getPatternHeight());
             payload.put("e_symmetry",             0.0);


### PR DESCRIPTION
## Summary

Closes #37 — all trades were being ML-filtered because 14 out of 19 features were hardcoded as `0.0`, causing the model to score everything below threshold.

- `PatternComboBacktestService`: expose `DailyIndicators` + `computeDailyIndicators` as public
- `PatternDto`: add 19 indicator fields (daily/watching/confirm RSI, ADX, MACD, BB)
- `PatternScanService.scan()`: load daily + confirm bar series, compute `DailyIndicators` for each TF, populate all fields at `keyLevelTime`
- `TradeFilterClient`: use real `macdHistAtP1/P2` and `stochRsiK` from pattern
- `PatternComboScannerService`: pass all real values to `score()` instead of zeros

## Test plan
- [ ] Run screener on a symbol with a known pattern — verify ML score is non-zero and varies by symbol
- [ ] Verify some trades pass filter (score ≥ 0.82) and some don't, rather than all being filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)