### PR TITLE
fix: move ML scoring from scan time to entry time

### DIFF
--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
@@ -26,7 +26,6 @@ public class PatternComboScannerService {
 
     private final PatternScanService patternScanService;
     private final TradeSignalRepository tradeSignalRepository;
-    private final TradeFilterClient tradeFilterClient;
     private final KiteTickerService kiteTickerService;
 
     @Value("${trade.monitor.entry.validity.hours:4}")
@@ -170,20 +169,7 @@ public class PatternComboScannerService {
                 .notes("Auto-scan: rsiP1=" + pattern.getRsiAtP1() + " rsiP2=" + pattern.getRsiAtP2())
                 .build();
 
-        // ML filter — score the pattern and store for reference, but do NOT gate here.
-        // Filtering happens at entry time (TradeEntryHandler) when the pattern has fully formed.
-        double prob = tradeFilterClient.score(
-                pattern, pattern.getPatternType(),
-                pattern.getDailyRsi(), pattern.getDailyAdx(), pattern.getDailyAdxEma(),
-                pattern.getAdxWatching(), pattern.getAdxWatchingEma(),
-                pattern.getAdxConfirm(), pattern.getAdxConfirmEma(),
-                pattern.getMacdWatching(), pattern.getMacdSignalWatching(),
-                pattern.getBbWidthWatching(), pattern.getBbPctBWatching(),
-                pattern.getMacdDaily(), pattern.getMacdSignalDaily(),
-                pattern.getBbWidthDaily(), pattern.getBbPctBDaily()
-        );
-        signal.setMlScore(BigDecimal.valueOf(prob).setScale(4, RoundingMode.HALF_UP));
-
+        // ML scoring happens at entry time (TradeEntryHandler) with live indicators — not here.
         signal = tradeSignalRepository.save(signal);
 
         log.info("[Scanner] New signal: {} {} {} keyLevel={}",

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternScanService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternScanService.java
@@ -6,6 +6,7 @@ import com.dtech.kitecon.backtest.PatternComboBacktestService;
 import com.dtech.kitecon.backtest.PatternComboBacktestService.DailyIndicators;
 import com.dtech.kitecon.repository.InstrumentRepository;
 import com.dtech.kitecon.data.Instrument;
+import com.dtech.kitecon.trade.entity.TradeSignal;
 import com.dtech.chartpattern.zigzag.ZigZagPoint;
 import com.dtech.chartpattern.zigzag.ZigZagService;
 import com.dtech.chartpattern.zigzag.ZigZagParams;
@@ -154,6 +155,79 @@ public class PatternScanService {
                 .watchingTfOverlays(watchingOverlays)
                 .confirmTfOverlays(confirmOverlays)
                 .build();
+    }
+
+    /**
+     * Computes live indicator values for a signal's symbol at the time of entry.
+     * Used by TradeEntryHandler to score the ML filter with fresh market data.
+     */
+    public PatternDto computeCurrentIndicators(TradeSignal signal) {
+        try {
+            String tfStr = signal.getTimeframe() != null ? signal.getTimeframe() : "1h";
+            Interval watchingTf = switch (tfStr.toLowerCase()) {
+                case "1d", "day", "d" -> Interval.Day;
+                case "15m", "15min"   -> Interval.FifteenMinute;
+                case "5m",  "5min"    -> Interval.FiveMinute;
+                default               -> Interval.OneHour;
+            };
+            Interval confirmTf = Interval.FifteenMinute;
+
+            Instrument instrument = instrumentRepository.findByTradingsymbolAndExchangeIn(
+                    signal.getSymbol(), new String[]{"NSE", "NFO"});
+            if (instrument == null) return null;
+
+            BarSeries seriesW = null;
+            BarSeries seriesDaily = null;
+            BarSeries seriesC = null;
+            try { seriesW = zigZagService.getBarSeries(signal.getSymbol(), instrument, watchingTf); } catch (Exception ignored) {}
+            try { seriesDaily = zigZagService.getBarSeries(signal.getSymbol(), instrument, Interval.Day); } catch (Exception ignored) {}
+            try { seriesC = zigZagService.getBarSeries(signal.getSymbol(), instrument, confirmTf); } catch (Exception ignored) {}
+
+            DailyIndicators watchingInd = patternComboBacktestService.computeDailyIndicators(seriesW);
+            DailyIndicators dailyInd    = patternComboBacktestService.computeDailyIndicators(seriesDaily);
+            DailyIndicators confirmInd  = patternComboBacktestService.computeDailyIndicators(seriesC);
+
+            double currentRsi = 0.0, currentMacdHist = 0.0, currentStochRsiK = 0.0;
+            if (seriesW != null && !seriesW.isEmpty()) {
+                double[] rsiArr      = patternComboBacktestService.computeRsiPublic(seriesW, 14);
+                double[] stochRsiArr = patternComboBacktestService.computeStochRsiKPublic(rsiArr);
+                double[] macdHistArr = patternComboBacktestService.computeMacdHistPublic(seriesW);
+                int last = seriesW.getBarCount() - 1;
+                currentRsi       = rsiArr[last];
+                currentMacdHist  = macdHistArr[last];
+                currentStochRsiK = stochRsiArr[last];
+            }
+
+            Instant now = Instant.now();
+            return PatternDto.builder()
+                    .patternType(signal.getPatternType())
+                    .rrRatio(signal.getRrRatio() != null ? signal.getRrRatio().doubleValue() : 0.0)
+                    .patternHeight(signal.getPatternHeight() != null ? signal.getPatternHeight().doubleValue() : 0.0)
+                    .rsiAtP1(currentRsi)
+                    .rsiAtP2(currentRsi)
+                    .macdHistAtP1(currentMacdHist)
+                    .macdHistAtP2(currentMacdHist)
+                    .stochRsiK(currentStochRsiK)
+                    .adxWatching(watchingInd.adxAtTs(now))
+                    .adxWatchingEma(watchingInd.adxEmaAtTs(now))
+                    .macdWatching(watchingInd.macdLineAtTs(now))
+                    .macdSignalWatching(watchingInd.macdSignalAtTs(now))
+                    .bbWidthWatching(watchingInd.bbWidthAtTs(now))
+                    .bbPctBWatching(watchingInd.bbPctBAtTs(now))
+                    .adxConfirm(confirmInd.adxAtTs(now))
+                    .adxConfirmEma(confirmInd.adxEmaAtTs(now))
+                    .dailyRsi(dailyInd.rsiAtTs(now))
+                    .dailyAdx(dailyInd.adxAtTs(now))
+                    .dailyAdxEma(dailyInd.adxEmaAtTs(now))
+                    .macdDaily(dailyInd.macdLineAtTs(now))
+                    .macdSignalDaily(dailyInd.macdSignalAtTs(now))
+                    .bbWidthDaily(dailyInd.bbWidthAtTs(now))
+                    .bbPctBDaily(dailyInd.bbPctBAtTs(now))
+                    .build();
+        } catch (Exception e) {
+            log.warn("[PatternScanService] computeCurrentIndicators failed for {}: {}", signal.getSymbol(), e.getMessage());
+            return null;
+        }
     }
 
     private Map<String, Object> buildOverlays(List<DetectedPattern> patterns, List<Bar> bars, Map<Instant, Integer> tsToIdx) {

--- a/src/main/java/com/dtech/kitecon/trade/service/TradeEntryHandler.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/TradeEntryHandler.java
@@ -1,5 +1,8 @@
 package com.dtech.kitecon.trade.service;
 
+import com.dtech.kitecon.patternscanner.PatternDto;
+import com.dtech.kitecon.patternscanner.PatternScanService;
+import com.dtech.kitecon.patternscanner.TradeFilterClient;
 import com.dtech.kitecon.trade.entity.TradeExecution;
 import com.dtech.kitecon.trade.entity.TradeMonitorLog;
 import com.dtech.kitecon.trade.entity.TradeSignal;
@@ -50,6 +53,8 @@ public class TradeEntryHandler {
     private final TradeExecutionRepository executionRepository;
     private final TradeMonitorLogRepository logRepository;
     private final TradeOrchestrationService tradeOrchestrationService;
+    private final PatternScanService patternScanService;
+    private final TradeFilterClient tradeFilterClient;
 
     @Transactional
     public void handle(TradeSignal signal, boolean dryRun) {
@@ -71,14 +76,18 @@ public class TradeEntryHandler {
 
         boolean entryTriggered = isEntryTriggered(signal, ltp);
 
-        if (entryTriggered && !passesMlFilter(signal)) {
-            signal.setStatus(TradeStatus.EXPIRED);
-            signalRepository.save(signal);
-            writeLog(signal, ltp, null, MonitorAction.SIGNAL_EXPIRED,
-                    "ML filter rejected at entry: score=" + signal.getMlScore() + " threshold=" + mlFilterThreshold, dryRun);
-            log.info("[EntryHandler] Signal {} {} ML-filtered at entry — score={} threshold={}",
-                    signal.getId(), signal.getSymbol(), signal.getMlScore(), mlFilterThreshold);
-            return;
+        if (entryTriggered) {
+            double score = scoreMlAtEntry(signal);
+            signal.setMlScore(BigDecimal.valueOf(score).setScale(4, java.math.RoundingMode.HALF_UP));
+            if (score < mlFilterThreshold) {
+                signal.setStatus(TradeStatus.EXPIRED);
+                signalRepository.save(signal);
+                writeLog(signal, ltp, null, MonitorAction.SIGNAL_EXPIRED,
+                        "ML filter rejected at entry: score=" + score + " threshold=" + mlFilterThreshold, dryRun);
+                log.info("[EntryHandler] Signal {} {} ML-filtered at entry — score={} threshold={}",
+                        signal.getId(), signal.getSymbol(), score, mlFilterThreshold);
+                return;
+            }
         }
 
         if (!entryTriggered) {
@@ -135,9 +144,29 @@ public class TradeEntryHandler {
         log.info("[EntryHandler] checkFill for signal {} — live order status check not yet implemented", signal.getId());
     }
 
-    private boolean passesMlFilter(TradeSignal signal) {
-        if (signal.getMlScore() == null) return true; // no score — let it through
-        return signal.getMlScore().doubleValue() >= mlFilterThreshold;
+    private double scoreMlAtEntry(TradeSignal signal) {
+        try {
+            PatternDto indicators = patternScanService.computeCurrentIndicators(signal);
+            if (indicators == null) {
+                log.warn("[EntryHandler] Could not compute indicators for {} — failing open", signal.getSymbol());
+                return 1.0;
+            }
+            double score = tradeFilterClient.score(
+                    indicators, signal.getPatternType(),
+                    indicators.getDailyRsi(), indicators.getDailyAdx(), indicators.getDailyAdxEma(),
+                    indicators.getAdxWatching(), indicators.getAdxWatchingEma(),
+                    indicators.getAdxConfirm(), indicators.getAdxConfirmEma(),
+                    indicators.getMacdWatching(), indicators.getMacdSignalWatching(),
+                    indicators.getBbWidthWatching(), indicators.getBbPctBWatching(),
+                    indicators.getMacdDaily(), indicators.getMacdSignalDaily(),
+                    indicators.getBbWidthDaily(), indicators.getBbPctBDaily()
+            );
+            log.info("[EntryHandler] ML score for signal {} {}: {}", signal.getId(), signal.getSymbol(), score);
+            return score;
+        } catch (Exception e) {
+            log.warn("[EntryHandler] ML scoring failed for signal {} — failing open: {}", signal.getId(), e.getMessage());
+            return 1.0;
+        }
     }
 
     private boolean isEntryTriggered(TradeSignal signal, BigDecimal ltp) {


### PR DESCRIPTION
## Summary

Closes #39 — ML service was being called at scan time with stale indicators. A forming pattern at scan time may look very different by the time price actually triggers entry.

- `PatternComboScannerService`: remove `TradeFilterClient` injection — signals saved with `mlScore = null`
- `PatternScanService`: add `computeCurrentIndicators(TradeSignal)` — loads fresh bar series for watching/daily/confirm TFs and computes live RSI, MACD, ADX, Bollinger Bands
- `TradeEntryHandler`: inject `PatternScanService` + `TradeFilterClient`, replace `passesMlFilter()` with `scoreMlAtEntry()` — called only after `isEntryTriggered()` with live data at that moment, score stored then threshold checked

## Test plan
- [ ] Run screener — verify signals created with `mlScore = null`
- [ ] When trade monitor ticks and entry triggers, verify logs show `[EntryHandler] ML score for signal X SYMBOL: Y`
- [ ] Verify some signals expire (score < 0.82) and others proceed to ACTIVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)