### PR TITLE
feat: TSL_HIT exit reason for trailing stop exits

### DIFF
--- a/src/main/java/com/dtech/kitecon/trade/entity/TradeActionLog.java
+++ b/src/main/java/com/dtech/kitecon/trade/entity/TradeActionLog.java
@@ -66,6 +66,7 @@ public class TradeActionLog {
         TARGET_UPDATED,
         SLAB_HIT,
         STOP_HIT,
+        TSL_HIT,
         TARGET_HIT,
         REVERSAL_EXIT,
         TIMEOUT_EXIT,

--- a/src/main/java/com/dtech/kitecon/trade/enums/ExitReason.java
+++ b/src/main/java/com/dtech/kitecon/trade/enums/ExitReason.java
@@ -3,6 +3,7 @@ package com.dtech.kitecon.trade.enums;
 public enum ExitReason {
     TARGET_HIT,
     STOP_HIT,
+    TSL_HIT,
     REVERSAL_CANDLE,
     MANUAL,
     EXPIRED,


### PR DESCRIPTION
## Summary
- Added `TSL_HIT` to `ExitReason` and `TradeActionLog.TradeAction` enums
- `ImpulseSlabExitStrategy` now returns `TSL_HIT` when price retraces after reaching a slab (currentSlab >= 0), vs `STOP_HIT` for initial stop loss (currentSlab < 0)

Closes #60

## Test plan
- [x] Verified: all 4 winners show TSL_HIT, all 6 losers show STOP_HIT in RELIANCE Jan-Mar sim

🤖 Generated with [Claude Code](https://claude.com/claude-code)