### PR TITLE
fix: scanner cron + pipeline null patternType

### DIFF
--- a/ui/chart-draw-app/src/pipeline/pages/PipelinePage.tsx
+++ b/ui/chart-draw-app/src/pipeline/pages/PipelinePage.tsx
@@ -260,7 +260,7 @@ export default function PipelinePage() {
           </div>
           <div>
             <span style={{ color: TEXT_SECONDARY, fontSize: 11 }}>Pattern</span>
-            <div style={{ fontSize: 14, fontWeight: 600, marginTop: 2 }}>{signal.patternType}</div>
+            <div style={{ fontSize: 14, fontWeight: 600, marginTop: 2 }}>{signal.patternType || signal.strategyType || '—'}</div>
           </div>
           <div>
             <span style={{ color: TEXT_SECONDARY, fontSize: 11 }}>Entry Price</span>
@@ -557,7 +557,7 @@ export default function PipelinePage() {
                       <td style={{ ...cellStyle, color: sig.direction === 'LONG' ? '#4caf50' : '#d32f2f' }}>
                         {sig.direction}
                       </td>
-                      <td style={cellStyle}>{sig.patternType}</td>
+                      <td style={cellStyle}>{sig.patternType || sig.strategyType || '—'}</td>
                       <td style={cellStyle}>{sig.entryPrice.toFixed(2)}</td>
                       <td style={cellStyle}>{sig.stopLoss.toFixed(2)}</td>
                       <td style={cellStyle}>{sig.target.toFixed(2)}</td>


### PR DESCRIPTION
## Summary
- Scanner cron restricted to market hours: `0 46 3-9 * * MON-FRI` (9:16-15:16 IST)
- Pipeline page: null-safe patternType rendering for impulse signals (falls back to strategyType)

Closes #72

## Test plan
- [x] `./gradlew compileJava` passes
- [ ] Verify scanner fires at next :46 UTC on prod
- [ ] Pipeline page renders impulse signals without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)