### PR TITLE
feat: live P&L on Trade Orders page

### DIFF
--- a/src/main/java/com/dtech/kitecon/trade/controller/TradeOrderController.java
+++ b/src/main/java/com/dtech/kitecon/trade/controller/TradeOrderController.java
@@ -1,9 +1,12 @@
 package com.dtech.kitecon.trade.controller;
 
+import com.dtech.kitecon.market.facade.MarketFacadeProvider;
 import com.dtech.kitecon.trade.dto.TradeSummaryDto;
 import com.dtech.kitecon.trade.entity.TradeOrder;
+import com.dtech.kitecon.trade.enums.TradeDirection;
 import com.dtech.kitecon.trade.enums.TradeOrderStatus;
 import com.dtech.kitecon.trade.repository.TradeOrderRepository;
+import com.zerodhatech.models.LTPQuote;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/trade-orders")
@@ -20,6 +24,7 @@ import java.util.List;
 public class TradeOrderController {
 
     private final TradeOrderRepository tradeOrderRepository;
+    private final MarketFacadeProvider marketFacadeProvider;
 
     @GetMapping("/")
     public ResponseEntity<List<TradeOrder>> getOrders(@RequestParam(required = false) String status) {
@@ -36,7 +41,53 @@ public class TradeOrderController {
             orders = tradeOrderRepository.findAllByOrderByCreatedAtDesc();
         }
 
+        enrichWithLivePnl(orders);
         return ResponseEntity.ok(orders);
+    }
+
+    private void enrichWithLivePnl(List<TradeOrder> orders) {
+        List<TradeOrder> openOrders = orders.stream()
+                .filter(o -> o.getStatus() == TradeOrderStatus.OPEN)
+                .toList();
+
+        if (openOrders.isEmpty()) return;
+
+        // Build instrument keys for batch LTP call: "NFO:SYMBOL" or "NSE:SYMBOL"
+        String[] instruments = openOrders.stream()
+                .map(o -> {
+                    String exchange = o.getSegment().name().equals("EQ") ? "NSE" : "NFO";
+                    return exchange + ":" + o.getSymbol();
+                })
+                .distinct()
+                .toArray(String[]::new);
+
+        try {
+            Map<String, LTPQuote> ltpMap = marketFacadeProvider.getFacade().getLTP(instruments);
+
+            for (TradeOrder order : openOrders) {
+                String exchange = order.getSegment().name().equals("EQ") ? "NSE" : "NFO";
+                String key = exchange + ":" + order.getSymbol();
+                LTPQuote quote = ltpMap.get(key);
+                if (quote == null) continue;
+
+                BigDecimal ltp = BigDecimal.valueOf(quote.lastPrice);
+                order.setLtp(ltp);
+
+                if (order.getEntryPrice() != null && order.getQuantity() != null) {
+                    BigDecimal pnl;
+                    if (order.getDirection() == TradeDirection.LONG) {
+                        pnl = ltp.subtract(order.getEntryPrice())
+                                .multiply(BigDecimal.valueOf(order.getQuantity()));
+                    } else {
+                        pnl = order.getEntryPrice().subtract(ltp)
+                                .multiply(BigDecimal.valueOf(order.getQuantity()));
+                    }
+                    order.setUnrealisedPnl(pnl.setScale(2, RoundingMode.HALF_UP));
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to fetch live LTP for open orders: {}", e.getMessage());
+        }
     }
 
     @GetMapping("/summary")

--- a/src/main/java/com/dtech/kitecon/trade/entity/TradeOrder.java
+++ b/src/main/java/com/dtech/kitecon/trade/entity/TradeOrder.java
@@ -100,6 +100,12 @@ public class TradeOrder {
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 
+    @Transient
+    private BigDecimal ltp;
+
+    @Transient
+    private BigDecimal unrealisedPnl;
+
     @PrePersist
     void prePersist() {
         Instant now = Instant.now();

--- a/ui/chart-draw-app/src/tradeMonitor/api.ts
+++ b/ui/chart-draw-app/src/tradeMonitor/api.ts
@@ -35,6 +35,8 @@ export interface TradeOrder {
   status: TradeOrderStatus;
   exitReason?: string;
   realisedPnl?: number;
+  ltp?: number;
+  unrealisedPnl?: number;
   underlyingEntryPrice?: number;
   underlyingExitPrice?: number;
   stopLoss?: number;

--- a/ui/chart-draw-app/src/tradeMonitor/pages/TradeOrdersPage.tsx
+++ b/ui/chart-draw-app/src/tradeMonitor/pages/TradeOrdersPage.tsx
@@ -308,6 +308,8 @@ const TradeOrdersPage: React.FC = () => {
             <th style={thStyle}>Stop</th>
             <th style={thStyle}>Target</th>
             <th style={thStyle}>P&L</th>
+            <th style={thStyle}>LTP</th>
+            <th style={thStyle}>Unreal P&L</th>
             <th style={thStyle}>Status</th>
             <th style={thStyle}>Exit Reason</th>
             <th style={thStyle}>Pattern</th>
@@ -317,7 +319,7 @@ const TradeOrdersPage: React.FC = () => {
           {orders.length === 0 ? (
             <tr>
               <td
-                colSpan={14}
+                colSpan={16}
                 style={{
                   ...tdStyle,
                   textAlign: "center",
@@ -392,6 +394,19 @@ const TradeOrdersPage: React.FC = () => {
                   )}
                 </td>
                 <td style={tdStyle}>
+                  {order.ltp != null ? order.ltp.toFixed(2) : "-"}
+                </td>
+                <td style={pnlStyle(order.unrealisedPnl)}>
+                  {order.unrealisedPnl != null ? (
+                    <>
+                      {order.unrealisedPnl > 0 ? "+" : ""}
+                      {order.unrealisedPnl.toFixed(2)}
+                    </>
+                  ) : (
+                    "-"
+                  )}
+                </td>
+                <td style={tdStyle}>
                   <span style={statusBadgeStyle(order.status)}>
                     {order.status}
                   </span>
@@ -401,7 +416,7 @@ const TradeOrdersPage: React.FC = () => {
               </tr>
               {expandedId === order.signal?.id && order.signal?.id && (
                 <tr key={`exp-${order.id}`}>
-                  <td colSpan={14} style={{ padding: 0 }}>
+                  <td colSpan={16} style={{ padding: 0 }}>
                     <TradeActionTimelineDark signalId={order.signal!.id} />
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- Batch-fetch LTP via Kite API for open orders, compute unrealised P&L
- Added LTP and Unreal P&L columns to Trade Orders table with color coding
- Refreshes every 30s via existing polling

Closes #74

## Test plan
- [x] `./gradlew compileJava` passes
- [ ] Open trade shows live LTP and unrealised P&L
- [ ] Closed trades show "-" for LTP/unrealised columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)