### PR TITLE
feat: live orders for impulse only

### DIFF
--- a/src/main/java/com/dtech/kitecon/trade/service/PaperOrderExecutionService.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/PaperOrderExecutionService.java
@@ -11,6 +11,7 @@ import com.dtech.kitecon.trade.entity.TradeSignal;
 import com.dtech.kitecon.trade.enums.ExitReason;
 import com.dtech.kitecon.trade.enums.TradeDirection;
 import com.dtech.kitecon.trade.enums.TradeOrderStatus;
+import com.dtech.kitecon.trade.enums.StrategyType;
 import com.dtech.kitecon.trade.enums.TradingSegment;
 import com.dtech.kitecon.trade.repository.TradeOrderRepository;
 import lombok.RequiredArgsConstructor;
@@ -83,8 +84,8 @@ public class PaperOrderExecutionService {
                 underlyingEntry, signal.getStopLoss(), signal.getTarget(),
                 resolved.getInstrumentType());
 
-        // Place live order on Kite if enabled
-        if (liveOrdersEnabled) {
+        // Place live order on Kite if enabled (impulse only — DTB stays paper)
+        if (liveOrdersEnabled && signal.getStrategyType() == StrategyType.IMPULSE) {
             try {
                 Instrument kiteInstrument = instrumentRepository.findByTradingsymbolAndExchangeIn(
                         resolved.getTradingSymbol(), new String[]{"NSE", "NFO"});

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -161,12 +161,10 @@ impulse.exit.max.bars=450
 impulse.prediction.url=http://localhost:8501/predict-batch
 impulse.max.trades.per.symbol=2
 impulse.otm.distance.pct=3
-impulse.paper.trade=true
-
+impulse.paper.trade=false
 
 # ── Impulse Live Trading Config ──
-# impulse.paper.trade=false   # UNCOMMENT FOR LIVE ORDERS
 impulse.capital.per.trade=25000
 impulse.otm.distance.pct=3
 impulse.simulation.segment=EQ
-impulse.live.orders=false
+impulse.live.orders=true


### PR DESCRIPTION
## Summary
- Gate live Kite order placement on StrategyType.IMPULSE — DTB stays paper
- Enable impulse.live.orders=true, impulse.paper.trade=false

## Test plan
- [x] compileJava passes
- [ ] Impulse signal places live Kite order
- [ ] DTB signal stays as paper trade

🤖 Generated with [Claude Code](https://claude.com/claude-code)