### PR TITLE
fix: remove invalid parentOrderId from orders

### DIFF
--- a/src/main/java/com/dtech/kitecon/market/orders/ZerodhaOrderManager.java
+++ b/src/main/java/com/dtech/kitecon/market/orders/ZerodhaOrderManager.java
@@ -37,8 +37,6 @@ public class ZerodhaOrderManager implements OrderManager {
       params.product = "NRML";
       params.orderType = "LIMIT";
       params.validity = "DAY";
-      params.disclosedQuantity = amount;
-      params.parentOrderId = UUID.randomUUID().toString();
       OrderResponse response = facade.placeOrder(params, "regular");
       return response.orderId;
     } catch (MarketException e) {


### PR DESCRIPTION
parentOrderId is for bracket orders, not regular. May cause 403 in kiteconnect 4.0.