### PR TITLE
feat: balance-based allocation + order product switch

### DIFF
--- a/src/main/java/com/dtech/dhan/facade/DhanMarketFacade.java
+++ b/src/main/java/com/dtech/dhan/facade/DhanMarketFacade.java
@@ -7,8 +7,10 @@ import com.dtech.kitecon.market.facade.MarketFacade;
 import com.zerodhatech.models.HistoricalData;
 import com.zerodhatech.models.Instrument;
 import com.zerodhatech.models.LTPQuote;
+import com.zerodhatech.models.Margin;
 import com.zerodhatech.models.Order;
 import com.zerodhatech.models.OrderParams;
+import com.zerodhatech.models.OrderResponse;
 import com.zerodhatech.models.Profile;
 import com.zerodhatech.models.Quote;
 import com.zerodhatech.models.Trade;
@@ -164,7 +166,7 @@ public class DhanMarketFacade implements MarketFacade {
     // ==================== Orders ====================
 
     @Override
-    public Order placeOrder(OrderParams params, String variety) throws MarketException {
+    public OrderResponse placeOrder(OrderParams params, String variety) throws MarketException {
         // TODO: Implement Dhan order placement
         throw new MarketException("dhan", "NOT_IMPLEMENTED",
             "Dhan order placement not yet implemented", null);
@@ -205,6 +207,11 @@ public class DhanMarketFacade implements MarketFacade {
     @Override
     public void setUserId(String userId) {
         // Not applicable for Dhan
+    }
+
+    @Override
+    public Margin getMargins(String segment) throws MarketException {
+        throw new MarketException("dhan", "501", "getMargins not implemented for Dhan", null);
     }
 
     // ==================== Helper Methods ====================

--- a/src/main/java/com/dtech/kitecon/market/facade/MarketFacade.java
+++ b/src/main/java/com/dtech/kitecon/market/facade/MarketFacade.java
@@ -153,4 +153,11 @@ public interface MarketFacade {
      * @param userId User ID
      */
     void setUserId(String userId);
+
+    /**
+     * Get account margins/funds for a segment.
+     * @param segment "equity" or "commodity"
+     * @return Margin object with available cash, utilised, etc.
+     */
+    Margin getMargins(String segment) throws MarketException;
 }

--- a/src/main/java/com/dtech/kitecon/market/facade/ZerodhaMarketFacade.java
+++ b/src/main/java/com/dtech/kitecon/market/facade/ZerodhaMarketFacade.java
@@ -164,6 +164,17 @@ public class ZerodhaMarketFacade implements MarketFacade {
         kiteConnect.setUserId(userId);
     }
 
+    @Override
+    public Margin getMargins(String segment) throws MarketException {
+        try {
+            return kiteConnect.getMargins(segment);
+        } catch (KiteException | IOException e) {
+            throw new MarketException("zerodha", extractErrorCode(e), "Failed to get margins", e);
+        } catch (Exception e) {
+            throw new MarketException("zerodha", "500", "Failed to get margins", e);
+        }
+    }
+
     // ==================== Helper Methods ====================
 
     /**

--- a/src/main/java/com/dtech/kitecon/market/orders/ZerodhaOrderManager.java
+++ b/src/main/java/com/dtech/kitecon/market/orders/ZerodhaOrderManager.java
@@ -12,15 +12,22 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @RequiredArgsConstructor(onConstructor = @__(@Autowired))
 @Component
 @Qualifier("zerodhaOrderManagerOld")
+@Slf4j
 public class ZerodhaOrderManager implements OrderManager {
   private final MarketFacadeProvider marketFacadeProvider;
+
+  // Order product type: MTF, CNC, MIS, NRML — configurable via property
+  @Value("${trade.order.product:MTF}")
+  private String orderProduct;
 
   @Override
   public String placeMISOrder(Double price, int amount, Instrument instrument, String orderType)
@@ -34,8 +41,7 @@ public class ZerodhaOrderManager implements OrderManager {
       params.transactionType = orderType.toUpperCase();
       params.quantity = amount;
       params.price = price;
-      // MTF for equity (NSE/BSE), NRML for derivatives (NFO/BFO)
-      params.product = "NFO".equals(exchange) || "BFO".equals(exchange) ? "NRML" : "MTF";
+      params.product = orderProduct;
       params.orderType = "LIMIT";
       params.validity = "DAY";
       OrderResponse response = facade.placeOrder(params, "regular");

--- a/src/main/java/com/dtech/kitecon/trade/service/CapitalAllocationService.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/CapitalAllocationService.java
@@ -1,5 +1,8 @@
 package com.dtech.kitecon.trade.service;
 
+import com.dtech.kitecon.market.facade.MarketFacadeProvider;
+import com.zerodhatech.models.Margin;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -8,13 +11,21 @@ import java.math.BigDecimal;
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class CapitalAllocationService {
 
+    private final MarketFacadeProvider marketFacadeProvider;
+
+    @Value("${trade.capital.allocation.pct:30}")
+    private double allocationPct;
+
     @Value("${trade.portfolio.value:500000}")
-    private long portfolioValue;
+    private long fallbackPortfolioValue;
 
     public int computeQuantity(BigDecimal capitalPct, BigDecimal price, int lotSize) {
-        double capital = portfolioValue * capitalPct.doubleValue() / 100.0;
+        double availableCapital = getAvailableCapital();
+        double capital = availableCapital * allocationPct / 100.0;
+
         int maxUnits = (int) (capital / price.doubleValue());
 
         int qty;
@@ -25,8 +36,21 @@ public class CapitalAllocationService {
             qty = numLots * lotSize;
         }
 
-        log.debug("CapitalAllocation: portfolioValue={} capitalPct={}% price={} lotSize={} → qty={}",
-                portfolioValue, capitalPct, price, lotSize, qty);
+        log.info("CapitalAllocation: available={} allocationPct={}% capital={} price={} lotSize={} → qty={}",
+                String.format("%.2f", availableCapital), allocationPct, String.format("%.2f", capital), price, lotSize, qty);
         return qty;
+    }
+
+    private double getAvailableCapital() {
+        try {
+            Margin margin = marketFacadeProvider.getFacade().getMargins("equity");
+            double cash = Double.parseDouble(margin.available.cash);
+            log.info("CapitalAllocation: fetched available cash from Kite: {}", cash);
+            return cash;
+        } catch (Exception e) {
+            log.warn("CapitalAllocation: failed to fetch margins, using fallback portfolioValue={}: {}",
+                    fallbackPortfolioValue, e.getMessage());
+            return fallbackPortfolioValue;
+        }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -168,3 +168,8 @@ impulse.capital.per.trade=25000
 impulse.otm.distance.pct=3
 impulse.simulation.segment=EQ
 impulse.live.orders=true
+
+# Order product type: MTF, CNC, MIS, NRML
+trade.order.product=MTF
+# Capital allocation: % of available balance per trade
+trade.capital.allocation.pct=30


### PR DESCRIPTION
## Summary
- Fetch available cash from Kite getMargins() API
- Allocate 30% of available balance per trade (configurable)
- Order product type configurable: MTF, CNC, MIS, NRML via `trade.order.product`

## Test plan
- [x] compileJava passes
- [ ] Verify margin fetch works during market hours
- [ ] MTF order placement on BSE/NSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)