### PR TITLE
test: T0.1 — Trade Execution Safety-Net Tests (78 tests)

### DIFF
--- a/src/test/java/com/dtech/kitecon/trade/service/InstrumentResolverServiceTest.java
+++ b/src/test/java/com/dtech/kitecon/trade/service/InstrumentResolverServiceTest.java
@@ -34,11 +34,12 @@ class InstrumentResolverServiceTest {
         Instrument inst = Instrument.builder()
                 .instrumentToken(12345L)
                 .tradingsymbol("RELIANCE")
+                .exchange("BSE")
                 .lotSize(1)
                 .instrumentType("EQ")
                 .build();
 
-        when(instrumentRepository.findAllByTradingsymbolAndExchangeIn("RELIANCE", new String[]{"NSE"}))
+        when(instrumentRepository.findAllByTradingsymbolAndExchangeIn("RELIANCE", new String[]{"BSE", "NSE"}))
                 .thenReturn(List.of(inst));
 
         ResolvedInstrument resolved = instrumentResolverService.resolve(
@@ -53,7 +54,7 @@ class InstrumentResolverServiceTest {
 
     @Test
     void testResolveEQ_NotFound() {
-        when(instrumentRepository.findAllByTradingsymbolAndExchangeIn("NOTFOUND", new String[]{"NSE"}))
+        when(instrumentRepository.findAllByTradingsymbolAndExchangeIn("NOTFOUND", new String[]{"BSE", "NSE"}))
                 .thenReturn(List.of());
 
         assertThrows(RuntimeException.class, () ->
@@ -157,5 +158,194 @@ class InstrumentResolverServiceTest {
 
         assertNotNull(resolved);
         assertEquals("PE", resolved.getInstrumentType());
+    }
+
+    @Test
+    void testResolveEQ_NotFound_ThrowsRuntimeException() {
+        when(instrumentRepository.findAllByTradingsymbolAndExchangeIn("NONEXISTENT", new String[]{"BSE", "NSE"}))
+                .thenReturn(List.of());
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
+                instrumentResolverService.resolve("NONEXISTENT", TradingSegment.EQ, TradeDirection.LONG, BigDecimal.valueOf(2500))
+        );
+
+        assertTrue(ex.getMessage().contains("EQ instrument not found"));
+    }
+
+    @Test
+    void testResolveEQ_BSEPreferredOverNSE() {
+        Instrument nseInst = Instrument.builder()
+                .instrumentToken(11111L)
+                .tradingsymbol("RELIANCE")
+                .exchange("NSE")
+                .lotSize(1)
+                .instrumentType("EQ")
+                .build();
+
+        Instrument bseInst = Instrument.builder()
+                .instrumentToken(22222L)
+                .tradingsymbol("RELIANCE")
+                .exchange("BSE")
+                .lotSize(1)
+                .instrumentType("EQ")
+                .build();
+
+        when(instrumentRepository.findAllByTradingsymbolAndExchangeIn("RELIANCE", new String[]{"BSE", "NSE"}))
+                .thenReturn(Arrays.asList(nseInst, bseInst));
+
+        ResolvedInstrument resolved = instrumentResolverService.resolve(
+                "RELIANCE", TradingSegment.EQ, TradeDirection.LONG, BigDecimal.valueOf(2500));
+
+        assertNotNull(resolved);
+        // BSE should be preferred over NSE
+        assertEquals(22222L, resolved.getInstrumentToken());
+    }
+
+    @Test
+    void testResolveFUT_NearestExpirySelected() {
+        LocalDateTime now = LocalDateTime.now();
+        Instrument fut1 = Instrument.builder()
+                .instrumentToken(100001L)
+                .tradingsymbol("BANKEX24DEC")
+                .lotSize(75)
+                .instrumentType("FUT")
+                .expiry(now.plusDays(10))
+                .build();
+
+        Instrument fut2 = Instrument.builder()
+                .instrumentToken(100002L)
+                .tradingsymbol("BANKEX24JAN")
+                .lotSize(75)
+                .instrumentType("FUT")
+                .expiry(now.plusDays(40))
+                .build();
+
+        Instrument fut3 = Instrument.builder()
+                .instrumentToken(100003L)
+                .tradingsymbol("BANKEX24FEB")
+                .lotSize(75)
+                .instrumentType("FUT")
+                .expiry(now.plusDays(70))
+                .build();
+
+        when(instrumentRepository.findAllByTradingsymbolStartingWithAndExpiryBetweenAndExchangeIn(
+                eq("BANKEX"), any(), any(), eq(new String[]{"NFO"})))
+                .thenReturn(Arrays.asList(fut2, fut1, fut3));
+
+        ResolvedInstrument resolved = instrumentResolverService.resolve(
+                "BANKEX", TradingSegment.FUT, TradeDirection.LONG, BigDecimal.valueOf(5000));
+
+        assertNotNull(resolved);
+        // Should select fut1 (earliest expiry at +10 days)
+        assertEquals("BANKEX24DEC", resolved.getTradingSymbol());
+        assertEquals(100001L, resolved.getInstrumentToken());
+    }
+
+    @Test
+    void testResolveFUT_NotFound_ThrowsRuntimeException() {
+        when(instrumentRepository.findAllByTradingsymbolStartingWithAndExpiryBetweenAndExchangeIn(
+                eq("NIFTY_INVALID"), any(), any(), eq(new String[]{"NFO"})))
+                .thenReturn(List.of());
+
+        RuntimeException ex = assertThrows(RuntimeException.class, () ->
+                instrumentResolverService.resolve("NIFTY_INVALID", TradingSegment.FUT, TradeDirection.LONG, BigDecimal.valueOf(20000))
+        );
+
+        assertTrue(ex.getMessage().contains("No FUT instrument found"));
+    }
+
+    @Test
+    void testResolveOPT_CE_ForLONG_PE_ForSHORT() {
+        LocalDateTime now = LocalDateTime.now();
+        Instrument ce2500 = Instrument.builder()
+                .instrumentToken(200001L)
+                .tradingsymbol("NIFTY24JAN2500CE")
+                .lotSize(100)
+                .instrumentType("CE")
+                .expiry(now.plusDays(30))
+                .strike("2500")
+                .build();
+
+        Instrument pe2500 = Instrument.builder()
+                .instrumentToken(300001L)
+                .tradingsymbol("NIFTY24JAN2500PE")
+                .lotSize(100)
+                .instrumentType("PE")
+                .expiry(now.plusDays(30))
+                .strike("2500")
+                .build();
+
+        // Test LONG → CE
+        when(instrumentRepository.findAllByTradingsymbolStartingWithAndExpiryBetweenAndExchangeIn(
+                eq("NIFTY"), any(), any(), eq(new String[]{"NFO"})))
+                .thenReturn(Arrays.asList(ce2500, pe2500));
+
+        ResolvedInstrument resolvedLong = instrumentResolverService.resolve(
+                "NIFTY", TradingSegment.OPT, TradeDirection.LONG, BigDecimal.valueOf(2480));
+
+        assertNotNull(resolvedLong);
+        assertEquals("CE", resolvedLong.getInstrumentType());
+
+        // Test SHORT → PE
+        ResolvedInstrument resolvedShort = instrumentResolverService.resolve(
+                "NIFTY", TradingSegment.OPT, TradeDirection.SHORT, BigDecimal.valueOf(2480));
+
+        assertNotNull(resolvedShort);
+        assertEquals("PE", resolvedShort.getInstrumentType());
+    }
+
+    @Test
+    void testResolveOPT_StrikeSelection_NearestToTarget() {
+        LocalDateTime now = LocalDateTime.now();
+        Instrument ce2400 = Instrument.builder()
+                .instrumentToken(200001L)
+                .tradingsymbol("SENSEX24JAN2400CE")
+                .lotSize(100)
+                .instrumentType("CE")
+                .expiry(now.plusDays(30))
+                .strike("2400")
+                .build();
+
+        Instrument ce2450 = Instrument.builder()
+                .instrumentToken(200002L)
+                .tradingsymbol("SENSEX24JAN2450CE")
+                .lotSize(100)
+                .instrumentType("CE")
+                .expiry(now.plusDays(30))
+                .strike("2450")
+                .build();
+
+        Instrument ce2500 = Instrument.builder()
+                .instrumentToken(200003L)
+                .tradingsymbol("SENSEX24JAN2500CE")
+                .lotSize(100)
+                .instrumentType("CE")
+                .expiry(now.plusDays(30))
+                .strike("2500")
+                .build();
+
+        Instrument ce2550 = Instrument.builder()
+                .instrumentToken(200004L)
+                .tradingsymbol("SENSEX24JAN2550CE")
+                .lotSize(100)
+                .instrumentType("CE")
+                .expiry(now.plusDays(30))
+                .strike("2550")
+                .build();
+
+        when(instrumentRepository.findAllByTradingsymbolStartingWithAndExpiryBetweenAndExchangeIn(
+                eq("SENSEX"), any(), any(), eq(new String[]{"NFO"})))
+                .thenReturn(Arrays.asList(ce2400, ce2450, ce2500, ce2550));
+
+        // Target price at 2475 — should select ce2500 (distance 25) over ce2450 (distance 25) or ce2400 (distance 75) or ce2550 (distance 75)
+        // Actually it will be ce2450 or ce2500 as they have same distance, but the algorithm picks nearest
+        ResolvedInstrument resolved = instrumentResolverService.resolve(
+                "SENSEX", TradingSegment.OPT, TradeDirection.LONG, BigDecimal.valueOf(2475));
+
+        assertNotNull(resolved);
+        assertEquals("CE", resolved.getInstrumentType());
+        // Should be one of the nearest strikes
+        assertTrue(resolved.getStrike().equals(BigDecimal.valueOf(2450)) ||
+                  resolved.getStrike().equals(BigDecimal.valueOf(2500)));
     }
 }

--- a/src/test/java/com/dtech/kitecon/trade/service/PaperOrderExecutionServiceTest.java
+++ b/src/test/java/com/dtech/kitecon/trade/service/PaperOrderExecutionServiceTest.java
@@ -1,5 +1,9 @@
 package com.dtech.kitecon.trade.service;
 
+import com.dtech.kitecon.data.Instrument;
+import com.dtech.kitecon.market.orders.OrderException;
+import com.dtech.kitecon.market.orders.OrderManager;
+import com.dtech.kitecon.repository.InstrumentRepository;
 import com.dtech.kitecon.trade.dto.QuoteResult;
 import com.dtech.kitecon.trade.dto.ResolvedInstrument;
 import com.dtech.kitecon.trade.entity.SegmentConfig;
@@ -13,15 +17,16 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class PaperOrderExecutionServiceTest {
@@ -31,6 +36,12 @@ class PaperOrderExecutionServiceTest {
 
     @Mock
     private CapitalAllocationService capitalAllocationService;
+
+    @Mock
+    private OrderManager orderManager;
+
+    @Mock
+    private InstrumentRepository instrumentRepository;
 
     @InjectMocks
     private PaperOrderExecutionService paperOrderExecutionService;
@@ -264,5 +275,552 @@ class PaperOrderExecutionServiceTest {
         assertNotNull(result);
         assertEquals(TradeOrderStatus.CLOSED, result.getStatus());
         assertTrue(result.getRealisedPnl().compareTo(BigDecimal.ZERO) > 0);
+    }
+
+    @Test
+    void testEnter_OPT_ForcesLONG() {
+        // Signal is SHORT, but OPT segment should force order direction to LONG
+        TradeSignal signal = TradeSignal.builder()
+                .id(1L)
+                .symbol("RELIANCE")
+                .direction(TradeDirection.SHORT)
+                .instrumentToken(123L)
+                .strategyType(StrategyType.DTB)
+                .build();
+
+        SegmentConfig config = SegmentConfig.builder()
+                .symbol("RELIANCE")
+                .segment(TradingSegment.OPT)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(2.0))
+                .build();
+
+        ResolvedInstrument resolved = ResolvedInstrument.builder()
+                .tradingSymbol("RELIANCE24JAN2500CE")
+                .instrumentToken(200001L)
+                .lotSize(100)
+                .instrumentType("CE")
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("RELIANCE24JAN2500CE")
+                .instrumentToken(200001L)
+                .ltp(BigDecimal.valueOf(50))
+                .askPrice(BigDecimal.valueOf(51))
+                .bidPrice(BigDecimal.valueOf(49))
+                .build();
+
+        when(capitalAllocationService.computeQuantity(any(), any(), anyInt())).thenReturn(1);
+
+        TradeOrder savedOrder = TradeOrder.builder()
+                .id(1L)
+                .signal(signal)
+                .symbol("RELIANCE24JAN2500CE")
+                .direction(TradeDirection.LONG)
+                .quantity(1)
+                .entryPrice(BigDecimal.valueOf(51))
+                .status(TradeOrderStatus.OPEN)
+                .paperTrade(true)
+                .build();
+
+        when(tradeOrderRepository.save(any())).thenReturn(savedOrder);
+
+        TradeOrder result = paperOrderExecutionService.enter(signal, config, resolved, quote, quote);
+
+        assertNotNull(result);
+        // OPT entry should force LONG direction, not SHORT from signal
+        assertEquals(TradeDirection.LONG, result.getDirection());
+        assertEquals(BigDecimal.valueOf(51), result.getEntryPrice());
+    }
+
+    @Test
+    void testEnter_EQ_LONG_UsesAskPrice() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(1L)
+                .symbol("INFY")
+                .direction(TradeDirection.LONG)
+                .instrumentToken(123L)
+                .build();
+
+        SegmentConfig config = SegmentConfig.builder()
+                .symbol("INFY")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(2.0))
+                .build();
+
+        ResolvedInstrument resolved = ResolvedInstrument.builder()
+                .tradingSymbol("INFY")
+                .instrumentToken(123L)
+                .lotSize(1)
+                .instrumentType("EQ")
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("INFY")
+                .instrumentToken(123L)
+                .ltp(BigDecimal.valueOf(3000))
+                .askPrice(BigDecimal.valueOf(3001))
+                .bidPrice(BigDecimal.valueOf(2999))
+                .build();
+
+        when(capitalAllocationService.computeQuantity(any(), any(), anyInt())).thenReturn(5);
+
+        TradeOrder savedOrder = TradeOrder.builder()
+                .id(1L)
+                .signal(signal)
+                .symbol("INFY")
+                .direction(TradeDirection.LONG)
+                .quantity(5)
+                .entryPrice(BigDecimal.valueOf(3001))
+                .status(TradeOrderStatus.OPEN)
+                .paperTrade(true)
+                .build();
+
+        when(tradeOrderRepository.save(any())).thenReturn(savedOrder);
+
+        TradeOrder result = paperOrderExecutionService.enter(signal, config, resolved, quote, quote);
+
+        assertNotNull(result);
+        // LONG entry should use ask price
+        assertEquals(BigDecimal.valueOf(3001), result.getEntryPrice());
+    }
+
+    @Test
+    void testEnter_EQ_SHORT_UsesBidPrice() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(1L)
+                .symbol("INFY")
+                .direction(TradeDirection.SHORT)
+                .instrumentToken(123L)
+                .build();
+
+        SegmentConfig config = SegmentConfig.builder()
+                .symbol("INFY")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(2.0))
+                .build();
+
+        ResolvedInstrument resolved = ResolvedInstrument.builder()
+                .tradingSymbol("INFY")
+                .instrumentToken(123L)
+                .lotSize(1)
+                .instrumentType("EQ")
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("INFY")
+                .instrumentToken(123L)
+                .ltp(BigDecimal.valueOf(3000))
+                .askPrice(BigDecimal.valueOf(3001))
+                .bidPrice(BigDecimal.valueOf(2999))
+                .build();
+
+        when(capitalAllocationService.computeQuantity(any(), any(), anyInt())).thenReturn(5);
+
+        TradeOrder savedOrder = TradeOrder.builder()
+                .id(1L)
+                .signal(signal)
+                .symbol("INFY")
+                .direction(TradeDirection.SHORT)
+                .quantity(5)
+                .entryPrice(BigDecimal.valueOf(2999))
+                .status(TradeOrderStatus.OPEN)
+                .paperTrade(true)
+                .build();
+
+        when(tradeOrderRepository.save(any())).thenReturn(savedOrder);
+
+        TradeOrder result = paperOrderExecutionService.enter(signal, config, resolved, quote, quote);
+
+        assertNotNull(result);
+        // SHORT entry should use bid price
+        assertEquals(BigDecimal.valueOf(2999), result.getEntryPrice());
+    }
+
+    @Test
+    void testExit_SHORT_Loss() {
+        TradeOrder order = TradeOrder.builder()
+                .id(1L)
+                .direction(TradeDirection.SHORT)
+                .quantity(10)
+                .entryPrice(BigDecimal.valueOf(2500))
+                .symbol("RELIANCE")
+                .instrumentToken(123L)
+                .status(TradeOrderStatus.OPEN)
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("RELIANCE")
+                .ltp(BigDecimal.valueOf(2510))
+                .askPrice(BigDecimal.valueOf(2511))
+                .bidPrice(BigDecimal.valueOf(2509))
+                .build();
+
+        TradeOrder exitedOrder = TradeOrder.builder()
+                .id(1L)
+                .direction(TradeDirection.SHORT)
+                .quantity(10)
+                .entryPrice(BigDecimal.valueOf(2500))
+                .exitPrice(BigDecimal.valueOf(2511))
+                .realisedPnl(BigDecimal.valueOf(-110))
+                .status(TradeOrderStatus.CLOSED)
+                .exitReason(ExitReason.STOP_HIT)
+                .build();
+
+        when(tradeOrderRepository.save(any())).thenReturn(exitedOrder);
+
+        TradeOrder result = paperOrderExecutionService.exit(order, quote, quote.getLtp(), ExitReason.STOP_HIT);
+
+        assertNotNull(result);
+        assertEquals(TradeOrderStatus.CLOSED, result.getStatus());
+        // SHORT loss: entry(2500) - exit(2511) * qty(10) = -110
+        assertTrue(result.getRealisedPnl().compareTo(BigDecimal.ZERO) < 0);
+    }
+
+    @Test
+    void testEnter_CapitalAllocationUsesLotSize() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(1L)
+                .symbol("RELIANCE")
+                .direction(TradeDirection.LONG)
+                .instrumentToken(123L)
+                .build();
+
+        SegmentConfig config = SegmentConfig.builder()
+                .symbol("RELIANCE")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(2.0))
+                .build();
+
+        ResolvedInstrument resolved = ResolvedInstrument.builder()
+                .tradingSymbol("RELIANCE")
+                .instrumentToken(123L)
+                .lotSize(1)
+                .instrumentType("EQ")
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("RELIANCE")
+                .instrumentToken(123L)
+                .ltp(BigDecimal.valueOf(2500))
+                .askPrice(BigDecimal.valueOf(2501))
+                .bidPrice(BigDecimal.valueOf(2499))
+                .build();
+
+        when(capitalAllocationService.computeQuantity(any(), any(), anyInt())).thenReturn(1);
+
+        TradeOrder savedOrder = TradeOrder.builder()
+                .id(1L)
+                .signal(signal)
+                .symbol("RELIANCE")
+                .direction(TradeDirection.LONG)
+                .quantity(1)
+                .entryPrice(BigDecimal.valueOf(2501))
+                .status(TradeOrderStatus.OPEN)
+                .build();
+
+        when(tradeOrderRepository.save(any())).thenReturn(savedOrder);
+
+        TradeOrder result = paperOrderExecutionService.enter(signal, config, resolved, quote, quote);
+
+        assertNotNull(result);
+        assertEquals(1, result.getQuantity());
+        verify(capitalAllocationService).computeQuantity(
+                BigDecimal.valueOf(2.0), BigDecimal.valueOf(2501), 1);
+    }
+
+    @Test
+    void testEnter_LiveOrderPlacementForIMPULSE() throws OrderException {
+        TradeSignal signal = TradeSignal.builder()
+                .id(1L)
+                .symbol("RELIANCE")
+                .direction(TradeDirection.LONG)
+                .instrumentToken(123L)
+                .strategyType(StrategyType.IMPULSE)
+                .build();
+
+        SegmentConfig config = SegmentConfig.builder()
+                .symbol("RELIANCE")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(2.0))
+                .orderProduct("MIS")
+                .build();
+
+        ResolvedInstrument resolved = ResolvedInstrument.builder()
+                .tradingSymbol("RELIANCE")
+                .instrumentToken(123L)
+                .lotSize(1)
+                .instrumentType("EQ")
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("RELIANCE")
+                .instrumentToken(123L)
+                .ltp(BigDecimal.valueOf(2500))
+                .askPrice(BigDecimal.valueOf(2501))
+                .bidPrice(BigDecimal.valueOf(2499))
+                .build();
+
+        Instrument kiteInstrument = Instrument.builder()
+                .instrumentToken(123L)
+                .tradingsymbol("RELIANCE")
+                .exchange("BSE")
+                .build();
+
+        when(capitalAllocationService.computeQuantity(any(), any(), anyInt())).thenReturn(10);
+        when(instrumentRepository.findAllByTradingsymbolAndExchangeIn("RELIANCE", new String[]{"BSE", "NSE", "NFO", "BFO"}))
+                .thenReturn(List.of(kiteInstrument));
+        when(orderManager.placeOrder(2501.0, 10, kiteInstrument, "BUY", "MIS")).thenReturn("ORDER123");
+
+        TradeOrder savedOrder = TradeOrder.builder()
+                .id(1L)
+                .signal(signal)
+                .symbol("RELIANCE")
+                .direction(TradeDirection.LONG)
+                .quantity(10)
+                .entryPrice(BigDecimal.valueOf(2501))
+                .status(TradeOrderStatus.OPEN)
+                .paperTrade(false)
+                .build();
+
+        when(tradeOrderRepository.save(any())).thenReturn(savedOrder);
+
+        // Enable live orders
+        ReflectionTestUtils.setField(paperOrderExecutionService, "liveOrdersEnabled", true);
+
+        TradeOrder result = paperOrderExecutionService.enter(signal, config, resolved, quote, quote);
+
+        assertNotNull(result);
+        assertFalse(result.isPaperTrade());
+        verify(orderManager).placeOrder(2501.0, 10, kiteInstrument, "BUY", "MIS");
+    }
+
+    @Test
+    void testEnter_LiveOrderPlacementException_FallsBackToPaper() throws OrderException {
+        TradeSignal signal = TradeSignal.builder()
+                .id(1L)
+                .symbol("RELIANCE")
+                .direction(TradeDirection.LONG)
+                .instrumentToken(123L)
+                .strategyType(StrategyType.IMPULSE)
+                .build();
+
+        SegmentConfig config = SegmentConfig.builder()
+                .symbol("RELIANCE")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(2.0))
+                .orderProduct("MIS")
+                .build();
+
+        ResolvedInstrument resolved = ResolvedInstrument.builder()
+                .tradingSymbol("RELIANCE")
+                .instrumentToken(123L)
+                .lotSize(1)
+                .instrumentType("EQ")
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("RELIANCE")
+                .instrumentToken(123L)
+                .ltp(BigDecimal.valueOf(2500))
+                .askPrice(BigDecimal.valueOf(2501))
+                .bidPrice(BigDecimal.valueOf(2499))
+                .build();
+
+        Instrument kiteInstrument = Instrument.builder()
+                .instrumentToken(123L)
+                .tradingsymbol("RELIANCE")
+                .exchange("BSE")
+                .build();
+
+        when(capitalAllocationService.computeQuantity(any(), any(), anyInt())).thenReturn(10);
+        when(instrumentRepository.findAllByTradingsymbolAndExchangeIn("RELIANCE", new String[]{"BSE", "NSE", "NFO", "BFO"}))
+                .thenReturn(List.of(kiteInstrument));
+        // OrderManager throws exception
+        when(orderManager.placeOrder(anyDouble(), anyInt(), any(), anyString(), anyString()))
+                .thenThrow(new OrderException(new RuntimeException("Order placement failed")));
+
+        TradeOrder savedOrder = TradeOrder.builder()
+                .id(1L)
+                .signal(signal)
+                .symbol("RELIANCE")
+                .direction(TradeDirection.LONG)
+                .quantity(10)
+                .entryPrice(BigDecimal.valueOf(2501))
+                .status(TradeOrderStatus.OPEN)
+                .paperTrade(true)
+                .build();
+
+        when(tradeOrderRepository.save(any())).thenReturn(savedOrder);
+
+        // Enable live orders
+        ReflectionTestUtils.setField(paperOrderExecutionService, "liveOrdersEnabled", true);
+
+        // Should not throw, should fall back to paper trade
+        TradeOrder result = paperOrderExecutionService.enter(signal, config, resolved, quote, quote);
+
+        assertNotNull(result);
+        assertTrue(result.isPaperTrade());
+    }
+
+    @Test
+    void testEnter_LiveOrderPlacementInstrumentNotFound_StaysPaper() throws OrderException {
+        TradeSignal signal = TradeSignal.builder()
+                .id(1L)
+                .symbol("UNKNOWN")
+                .direction(TradeDirection.LONG)
+                .instrumentToken(999L)
+                .strategyType(StrategyType.IMPULSE)
+                .build();
+
+        SegmentConfig config = SegmentConfig.builder()
+                .symbol("UNKNOWN")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(2.0))
+                .orderProduct("MIS")
+                .build();
+
+        ResolvedInstrument resolved = ResolvedInstrument.builder()
+                .tradingSymbol("UNKNOWN")
+                .instrumentToken(999L)
+                .lotSize(1)
+                .instrumentType("EQ")
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("UNKNOWN")
+                .instrumentToken(999L)
+                .ltp(BigDecimal.valueOf(100))
+                .askPrice(BigDecimal.valueOf(101))
+                .bidPrice(BigDecimal.valueOf(99))
+                .build();
+
+        when(capitalAllocationService.computeQuantity(any(), any(), anyInt())).thenReturn(1);
+        // Instrument not found
+        when(instrumentRepository.findAllByTradingsymbolAndExchangeIn("UNKNOWN", new String[]{"BSE", "NSE", "NFO", "BFO"}))
+                .thenReturn(List.of());
+
+        TradeOrder savedOrder = TradeOrder.builder()
+                .id(1L)
+                .signal(signal)
+                .symbol("UNKNOWN")
+                .direction(TradeDirection.LONG)
+                .quantity(1)
+                .entryPrice(BigDecimal.valueOf(101))
+                .status(TradeOrderStatus.OPEN)
+                .paperTrade(true)
+                .build();
+
+        when(tradeOrderRepository.save(any())).thenReturn(savedOrder);
+
+        // Enable live orders
+        ReflectionTestUtils.setField(paperOrderExecutionService, "liveOrdersEnabled", true);
+
+        TradeOrder result = paperOrderExecutionService.enter(signal, config, resolved, quote, quote);
+
+        assertNotNull(result);
+        assertTrue(result.isPaperTrade());
+        verify(orderManager, never()).placeOrder(anyDouble(), anyInt(), any(), anyString(), anyString());
+    }
+
+    @Test
+    void testExit_ExitReasonStoredCorrectly() {
+        TradeOrder order = TradeOrder.builder()
+                .id(1L)
+                .direction(TradeDirection.LONG)
+                .quantity(5)
+                .entryPrice(BigDecimal.valueOf(1000))
+                .symbol("SBIN")
+                .instrumentToken(456L)
+                .status(TradeOrderStatus.OPEN)
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("SBIN")
+                .ltp(BigDecimal.valueOf(1050))
+                .askPrice(BigDecimal.valueOf(1051))
+                .bidPrice(BigDecimal.valueOf(1049))
+                .build();
+
+        TradeOrder exitedOrder = TradeOrder.builder()
+                .id(1L)
+                .direction(TradeDirection.LONG)
+                .quantity(5)
+                .entryPrice(BigDecimal.valueOf(1000))
+                .exitPrice(BigDecimal.valueOf(1049))
+                .realisedPnl(BigDecimal.valueOf(245))
+                .status(TradeOrderStatus.CLOSED)
+                .exitReason(ExitReason.TARGET_HIT)
+                .build();
+
+        when(tradeOrderRepository.save(any())).thenReturn(exitedOrder);
+
+        TradeOrder result = paperOrderExecutionService.exit(order, quote, quote.getLtp(), ExitReason.TARGET_HIT);
+
+        assertNotNull(result);
+        assertEquals(ExitReason.TARGET_HIT, result.getExitReason());
+        verify(tradeOrderRepository).save(argThat(o -> o.getExitReason() == ExitReason.TARGET_HIT));
+    }
+
+    @Test
+    void testEnter_PaperTradeFlag_DefaultTrue() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(1L)
+                .symbol("TCS")
+                .direction(TradeDirection.LONG)
+                .instrumentToken(789L)
+                .strategyType(StrategyType.DTB)
+                .build();
+
+        SegmentConfig config = SegmentConfig.builder()
+                .symbol("TCS")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(1.5))
+                .build();
+
+        ResolvedInstrument resolved = ResolvedInstrument.builder()
+                .tradingSymbol("TCS")
+                .instrumentToken(789L)
+                .lotSize(1)
+                .instrumentType("EQ")
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("TCS")
+                .instrumentToken(789L)
+                .ltp(BigDecimal.valueOf(3500))
+                .askPrice(BigDecimal.valueOf(3501))
+                .bidPrice(BigDecimal.valueOf(3499))
+                .build();
+
+        when(capitalAllocationService.computeQuantity(any(), any(), anyInt())).thenReturn(1);
+
+        TradeOrder savedOrder = TradeOrder.builder()
+                .id(1L)
+                .signal(signal)
+                .symbol("TCS")
+                .direction(TradeDirection.LONG)
+                .quantity(1)
+                .entryPrice(BigDecimal.valueOf(3501))
+                .status(TradeOrderStatus.OPEN)
+                .paperTrade(true)
+                .build();
+
+        when(tradeOrderRepository.save(any())).thenReturn(savedOrder);
+
+        // Live orders disabled (default)
+        ReflectionTestUtils.setField(paperOrderExecutionService, "liveOrdersEnabled", false);
+
+        TradeOrder result = paperOrderExecutionService.enter(signal, config, resolved, quote, quote);
+
+        assertNotNull(result);
+        assertTrue(result.isPaperTrade());
     }
 }

--- a/src/test/java/com/dtech/kitecon/trade/service/TradeEntryHandlerTest.java
+++ b/src/test/java/com/dtech/kitecon/trade/service/TradeEntryHandlerTest.java
@@ -1,0 +1,473 @@
+package com.dtech.kitecon.trade.service;
+
+import com.dtech.kitecon.patternscanner.PatternDto;
+import com.dtech.kitecon.patternscanner.PatternScanService;
+import com.dtech.kitecon.patternscanner.TradeFilterClient;
+import com.dtech.kitecon.trade.entity.TradeActionLog;
+import com.dtech.kitecon.trade.entity.TradeExecution;
+import com.dtech.kitecon.trade.entity.TradeMonitorLog;
+import com.dtech.kitecon.trade.entity.TradeSignal;
+import com.dtech.kitecon.trade.enums.MonitorAction;
+import com.dtech.kitecon.trade.enums.TradeDirection;
+import com.dtech.kitecon.trade.enums.TradeStatus;
+import com.dtech.kitecon.trade.repository.TradeExecutionRepository;
+import com.dtech.kitecon.trade.repository.TradeMonitorLogRepository;
+import com.dtech.kitecon.trade.repository.TradeSignalRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Safety-net unit tests for TradeEntryHandler.
+ * Pin current behavior before refactoring.
+ * Pure Mockito tests — no Spring context.
+ */
+@ExtendWith(MockitoExtension.class)
+class TradeEntryHandlerTest {
+
+    @Mock
+    private BrokerOrderService brokerOrderService;
+
+    @Mock
+    private TradeSignalRepository signalRepository;
+
+    @Mock
+    private TradeExecutionRepository executionRepository;
+
+    @Mock
+    private TradeMonitorLogRepository logRepository;
+
+    @Mock
+    private TradeOrchestrationService tradeOrchestrationService;
+
+    @Mock
+    private PatternScanService patternScanService;
+
+    @Mock
+    private TradeFilterClient tradeFilterClient;
+
+    @Mock
+    private TradeActionLogger tradeActionLogger;
+
+    @InjectMocks
+    private TradeEntryHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        // Set @Value fields
+        ReflectionTestUtils.setField(handler, "mlFilterThreshold", 0.82);
+        ReflectionTestUtils.setField(handler, "notionalPerLot", 1000000L);
+        ReflectionTestUtils.setField(handler, "marginPerLot", 300000L);
+    }
+
+    /**
+     * Test 1: Entry triggered for LONG position when LTP >= entry price
+     * Dry-run mode: execution created with DRY-RUN order ID, status = ACTIVE
+     */
+    @Test
+    void testEntryTriggeredLong() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.LONG, "100.00", "99.00", "101.00");
+        signal.setId(1L);
+        BigDecimal ltp = new BigDecimal("100.50");
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(ltp);
+        PatternDto patternDto = createPatternDto();
+        when(patternScanService.computeCurrentIndicators(signal)).thenReturn(patternDto);
+        when(tradeFilterClient.score(eq(patternDto), eq("TEST_PATTERN"), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(0.85); // Above threshold
+
+        // Act
+        handler.handle(signal, true); // dryRun = true
+
+        // Assert
+        ArgumentCaptor<TradeExecution> executionCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(executionCaptor.capture());
+        TradeExecution execution = executionCaptor.getValue();
+        assertEquals("DRY-RUN-ENTRY-1", execution.getEntryOrderId());
+        assertEquals(ltp, execution.getEntryPriceActual());
+
+        ArgumentCaptor<TradeSignal> signalCaptor = ArgumentCaptor.forClass(TradeSignal.class);
+        verify(signalRepository).save(signalCaptor.capture()); // Only once for ACTIVE (ML score set but not saved)
+        assertEquals(TradeStatus.ACTIVE, signalCaptor.getValue().getStatus());
+    }
+
+    /**
+     * Test 2: Entry triggered for SHORT position when LTP <= entry price
+     */
+    @Test
+    void testEntryTriggeredShort() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.SHORT, "100.00", "101.00", "99.00");
+        signal.setId(2L);
+        BigDecimal ltp = new BigDecimal("99.50");
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(ltp);
+        PatternDto patternDto2 = createPatternDto();
+        when(patternScanService.computeCurrentIndicators(signal)).thenReturn(patternDto2);
+        when(tradeFilterClient.score(eq(patternDto2), eq("TEST_PATTERN"), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(0.90); // Above threshold
+
+        // Act
+        handler.handle(signal, true); // dryRun = true
+
+        // Assert
+        ArgumentCaptor<TradeExecution> executionCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(executionCaptor.capture());
+        TradeExecution execution = executionCaptor.getValue();
+        assertEquals("DRY-RUN-ENTRY-2", execution.getEntryOrderId());
+    }
+
+    /**
+     * Test 3: Entry NOT triggered for LONG when LTP < entry price
+     */
+    @Test
+    void testEntryNotTriggeredLongPriceBelowEntry() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.LONG, "100.00", "99.00", "101.00");
+        signal.setId(3L);
+        BigDecimal ltp = new BigDecimal("99.50"); // Below entry
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(ltp);
+
+        // Act
+        handler.handle(signal, true);
+
+        // Assert
+        verify(executionRepository, never()).save(any(TradeExecution.class));
+        verify(signalRepository, never()).save(signal);
+
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        TradeMonitorLog log = logCaptor.getValue();
+        assertEquals(MonitorAction.NONE, log.getActionTaken());
+        assertTrue(log.getActionDetail().contains("Watching entry"));
+    }
+
+    /**
+     * Test 4: Entry NOT triggered for SHORT when LTP > entry price
+     */
+    @Test
+    void testEntryNotTriggeredShortPriceAboveEntry() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.SHORT, "100.00", "101.00", "99.00");
+        signal.setId(4L);
+        BigDecimal ltp = new BigDecimal("100.50"); // Above entry
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(ltp);
+
+        // Act
+        handler.handle(signal, true);
+
+        // Assert
+        verify(executionRepository, never()).save(any(TradeExecution.class));
+        verify(logRepository).save(any(TradeMonitorLog.class));
+    }
+
+    /**
+     * Test 5: Entry window expired → signal status set to EXPIRED
+     */
+    @Test
+    void testEntryExpiredWindowClosed() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.LONG, "100.00", "99.00", "101.00");
+        signal.setId(5L);
+        signal.setEntryValidUntil(Instant.now().minusSeconds(3600)); // Expired 1 hour ago
+
+        // Act
+        handler.handle(signal, true);
+
+        // Assert
+        ArgumentCaptor<TradeSignal> signalCaptor = ArgumentCaptor.forClass(TradeSignal.class);
+        verify(signalRepository).save(signalCaptor.capture());
+        assertEquals(TradeStatus.EXPIRED, signalCaptor.getValue().getStatus());
+
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        assertEquals(MonitorAction.SIGNAL_EXPIRED, logCaptor.getValue().getActionTaken());
+
+        verify(brokerOrderService, never()).fetchLtp(anyString(), any());
+    }
+
+    /**
+     * Test 6: Entry triggered but ML filter rejects (score < threshold)
+     */
+    @Test
+    void testMlFilterRejectsEntry() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.LONG, "100.00", "99.00", "101.00");
+        signal.setId(6L);
+        BigDecimal ltp = new BigDecimal("100.50");
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(ltp);
+        PatternDto patternDto6 = createPatternDto();
+        when(patternScanService.computeCurrentIndicators(signal)).thenReturn(patternDto6);
+        when(tradeFilterClient.score(eq(patternDto6), eq("TEST_PATTERN"), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(0.75); // Below threshold (0.82)
+
+        // Act
+        handler.handle(signal, true);
+
+        // Assert
+        ArgumentCaptor<TradeSignal> signalCaptor = ArgumentCaptor.forClass(TradeSignal.class);
+        verify(signalRepository).save(signalCaptor.capture());
+        assertEquals(TradeStatus.EXPIRED, signalCaptor.getValue().getStatus());
+
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        assertTrue(logCaptor.getValue().getActionDetail().contains("ML filter rejected"));
+
+        verify(executionRepository, never()).save(any(TradeExecution.class));
+    }
+
+    /**
+     * Test 7: Entry triggered with ML score exactly at threshold → entry proceeds
+     */
+    @Test
+    void testMlFilterThresholdExactlyMet() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.LONG, "100.00", "99.00", "101.00");
+        signal.setId(7L);
+        BigDecimal ltp = new BigDecimal("100.50");
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(ltp);
+        PatternDto patternDto7 = createPatternDto();
+        when(patternScanService.computeCurrentIndicators(signal)).thenReturn(patternDto7);
+        when(tradeFilterClient.score(eq(patternDto7), eq("TEST_PATTERN"), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(0.82); // Exactly at threshold
+
+        // Act
+        handler.handle(signal, true);
+
+        // Assert
+        ArgumentCaptor<TradeExecution> executionCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(executionCaptor.capture());
+        assertNotNull(executionCaptor.getValue());
+
+        ArgumentCaptor<TradeSignal> signalCaptor = ArgumentCaptor.forClass(TradeSignal.class);
+        verify(signalRepository).save(signalCaptor.capture()); // Only once for ACTIVE (ML score set but not saved)
+        assertEquals(TradeStatus.ACTIVE, signalCaptor.getValue().getStatus());
+    }
+
+    /**
+     * Test 8: ML scoring exception → fail open (score = 0.9999, entry proceeds)
+     */
+    @Test
+    void testMlScoringException() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.LONG, "100.00", "99.00", "101.00");
+        signal.setId(8L);
+        BigDecimal ltp = new BigDecimal("100.50");
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(ltp);
+        when(patternScanService.computeCurrentIndicators(signal))
+                .thenThrow(new RuntimeException("ML service unavailable"));
+
+        // Act
+        handler.handle(signal, true);
+
+        // Assert — entry should proceed despite exception (fail open)
+        ArgumentCaptor<TradeExecution> executionCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(executionCaptor.capture());
+        assertNotNull(executionCaptor.getValue());
+
+        ArgumentCaptor<TradeSignal> signalCaptor = ArgumentCaptor.forClass(TradeSignal.class);
+        verify(signalRepository).save(signalCaptor.capture()); // Only once for ACTIVE (ML score set but not saved)
+        assertEquals(TradeStatus.ACTIVE, signalCaptor.getValue().getStatus());
+    }
+
+    /**
+     * Test 9: LTP fetch failure (null) → skip tick, no crash, no status change
+     */
+    @Test
+    void testLtpFetchFailure() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.LONG, "100.00", "99.00", "101.00");
+        signal.setId(9L);
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(null);
+
+        // Act
+        handler.handle(signal, true);
+
+        // Assert
+        verify(executionRepository, never()).save(any(TradeExecution.class));
+        verify(signalRepository, never()).save(signal);
+
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        assertEquals(MonitorAction.NONE, logCaptor.getValue().getActionTaken());
+        assertTrue(logCaptor.getValue().getActionDetail().contains("LTP unavailable"));
+    }
+
+    /**
+     * Test 10: Dry-run mode creates execution with proper DRY-RUN order ID
+     */
+    @Test
+    void testDryRunCreatesExecutionWithProperOrderId() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.LONG, "100.00", "99.00", "101.00");
+        signal.setId(10L);
+        BigDecimal ltp = new BigDecimal("100.50");
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(ltp);
+        PatternDto patternDto10 = createPatternDto();
+        when(patternScanService.computeCurrentIndicators(signal)).thenReturn(patternDto10);
+        when(tradeFilterClient.score(eq(patternDto10), eq("TEST_PATTERN"), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(0.85);
+
+        // Act
+        handler.handle(signal, true); // dryRun = true
+
+        // Assert
+        ArgumentCaptor<TradeExecution> executionCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(executionCaptor.capture());
+        TradeExecution execution = executionCaptor.getValue();
+        assertEquals("DRY-RUN-ENTRY-10", execution.getEntryOrderId());
+        assertEquals(signal, execution.getSignal());
+        assertEquals(1, execution.getQuantity()); // lotSize defaults to 1
+        assertEquals(new BigDecimal("1000000"), execution.getNotionalValue());
+        assertEquals(new BigDecimal("300000"), execution.getMarginDeployed());
+    }
+
+    /**
+     * Test 11: Live mode places market order, status set to ENTRY_PENDING
+     */
+    @Test
+    void testLiveRunPlacesMarketOrder() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.LONG, "100.00", "99.00", "101.00");
+        signal.setId(11L);
+        BigDecimal ltp = new BigDecimal("100.50");
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(ltp);
+        PatternDto patternDto11 = createPatternDto();
+        when(patternScanService.computeCurrentIndicators(signal)).thenReturn(patternDto11);
+        when(tradeFilterClient.score(eq(patternDto11), eq("TEST_PATTERN"), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(0.85);
+        when(brokerOrderService.placeMarketOrder(signal)).thenReturn("ORDER-12345");
+
+        // Act
+        handler.handle(signal, false); // dryRun = false
+
+        // Assert
+        verify(brokerOrderService).placeMarketOrder(signal);
+        verify(executionRepository, never()).save(any(TradeExecution.class)); // Not saved in live mode yet
+
+        ArgumentCaptor<TradeSignal> signalCaptor = ArgumentCaptor.forClass(TradeSignal.class);
+        verify(signalRepository).save(signalCaptor.capture()); // Only once for ENTRY_PENDING (ML score set but not saved)
+        assertEquals(TradeStatus.ENTRY_PENDING, signalCaptor.getValue().getStatus());
+        assertTrue(signalCaptor.getValue().getNotes().contains("entryOrder=ORDER-12345"));
+
+        verify(tradeOrchestrationService, never()).onEntryTriggered(any());
+    }
+
+    /**
+     * Test 12: TradeActionLog created on entry trigger
+     */
+    @Test
+    void testTradeActionLogCreatedOnEntry() {
+        // Arrange
+        TradeSignal signal = createSignal(TradeDirection.LONG, "100.00", "99.00", "101.00");
+        signal.setId(12L);
+        BigDecimal ltp = new BigDecimal("100.50");
+
+        when(brokerOrderService.fetchLtp(anyString(), anyLong())).thenReturn(ltp);
+        PatternDto patternDto12 = createPatternDto();
+        when(patternScanService.computeCurrentIndicators(signal)).thenReturn(patternDto12);
+        when(tradeFilterClient.score(eq(patternDto12), eq("TEST_PATTERN"), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(), anyDouble(),
+                anyDouble(), anyDouble(), anyDouble()))
+                .thenReturn(0.85);
+
+        // Act
+        handler.handle(signal, true);
+
+        // Assert
+        verify(tradeActionLogger).log(signal, TradeActionLog.TradeAction.ENTRY_TRIGGERED, ltp,
+                "Entry condition met");
+        verify(tradeActionLogger).log(signal, TradeActionLog.TradeAction.ENTRY_FILLED, ltp, "Filled");
+    }
+
+    /**
+     * Helper method to create a test signal
+     */
+    private TradeSignal createSignal(TradeDirection direction, String entryPrice, String stopLoss, String target) {
+        return TradeSignal.builder()
+                .symbol(direction == TradeDirection.LONG ? "HDFCBANK" : "RELIANCE")
+                .instrumentToken(direction == TradeDirection.LONG ? 123L : 456L)
+                .direction(direction)
+                .entryPrice(new BigDecimal(entryPrice))
+                .stopLoss(new BigDecimal(stopLoss))
+                .target(new BigDecimal(target))
+                .lotSize(1)
+                .status(TradeStatus.WATCHING_ENTRY)
+                .patternType("TEST_PATTERN")
+                .signalTime(Instant.now())
+                .candleTime(Instant.now())
+                .build();
+    }
+
+    /**
+     * Helper method to create a test PatternDto
+     */
+    private PatternDto createPatternDto() {
+        return PatternDto.builder()
+                .patternType("TEST_PATTERN")
+                .bullish(true)
+                .keyLevel(100.0)
+                .target(105.0)
+                .dailyRsi(55.0)
+                .dailyAdx(25.0)
+                .dailyAdxEma(24.0)
+                .adxWatching(20.0)
+                .adxWatchingEma(19.0)
+                .adxConfirm(22.0)
+                .adxConfirmEma(21.0)
+                .macdWatching(0.5)
+                .macdSignalWatching(0.4)
+                .bbWidthWatching(2.0)
+                .bbPctBWatching(0.5)
+                .macdDaily(0.3)
+                .macdSignalDaily(0.2)
+                .bbWidthDaily(3.0)
+                .bbPctBDaily(0.6)
+                .bbExpanding(1.0)
+                .bbAligned(1.0)
+                .rsiSlope(0.5)
+                .macdHistSlope(0.3)
+                .adxSlope(0.2)
+                .build();
+    }
+}

--- a/src/test/java/com/dtech/kitecon/trade/service/TradeExitHandlerTest.java
+++ b/src/test/java/com/dtech/kitecon/trade/service/TradeExitHandlerTest.java
@@ -1,0 +1,613 @@
+package com.dtech.kitecon.trade.service;
+
+import com.dtech.kitecon.trade.entity.TradeActionLog;
+import com.dtech.kitecon.trade.entity.TradeExecution;
+import com.dtech.kitecon.trade.entity.TradeMonitorLog;
+import com.dtech.kitecon.trade.entity.TradeSignal;
+import com.dtech.kitecon.trade.enums.ExitReason;
+import com.dtech.kitecon.trade.enums.MonitorAction;
+import com.dtech.kitecon.trade.enums.StrategyType;
+import com.dtech.kitecon.trade.enums.TradeDirection;
+import com.dtech.kitecon.trade.enums.TradeStatus;
+import com.dtech.kitecon.trade.repository.TradeExecutionRepository;
+import com.dtech.kitecon.trade.repository.TradeMonitorLogRepository;
+import com.dtech.kitecon.trade.repository.TradeSignalRepository;
+import com.dtech.kitecon.trade.strategy.ExitDecision;
+import com.dtech.kitecon.trade.strategy.ExitStrategy;
+import com.dtech.kitecon.trade.strategy.ExitStrategyRouter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Safety-net unit tests for TradeExitHandler.
+ * Pins current behavior before refactoring.
+ *
+ * No Spring context — pure Mockito with @ExtendWith(MockitoExtension.class)
+ */
+@ExtendWith(MockitoExtension.class)
+class TradeExitHandlerTest {
+
+    private static final BigDecimal BROKERAGE_PER_TRADE = BigDecimal.valueOf(1500);
+
+    @Mock
+    private BrokerOrderService brokerOrderService;
+
+    @Mock
+    private TradeSignalRepository signalRepository;
+
+    @Mock
+    private TradeExecutionRepository executionRepository;
+
+    @Mock
+    private TradeMonitorLogRepository logRepository;
+
+    @Mock
+    private TradeOrchestrationService tradeOrchestrationService;
+
+    @Mock
+    private RlExitClient rlExitClient;
+
+    @Mock
+    private ExitStrategyRouter exitStrategyRouter;
+
+    @Mock
+    private TradeActionLogger tradeActionLogger;
+
+    @InjectMocks
+    private TradeExitHandler handler;
+
+    private TradeSignal signal;
+    private TradeExecution execution;
+
+    @BeforeEach
+    void setUp() {
+        // Set dryRun to true by default (can be overridden in tests)
+        ReflectionTestUtils.setField(handler, "dryRun", true);
+
+        // Create a sample signal
+        signal = new TradeSignal();
+        signal.setId(1L);
+        signal.setSymbol("HDFCBANK");
+        signal.setInstrumentToken(100L);
+        signal.setDirection(TradeDirection.LONG);
+        signal.setStrategyType(StrategyType.DTB);
+        signal.setInstrumentType("EQ");
+        signal.setStopLoss(new BigDecimal("1500.00"));
+        signal.setTarget(new BigDecimal("1700.00"));
+        signal.setStatus(TradeStatus.ACTIVE);
+
+        // Create a sample execution
+        execution = new TradeExecution();
+        execution.setId(1L);
+        execution.setSignal(signal);
+        execution.setEntryPriceActual(new BigDecimal("1600.00"));
+        execution.setNotionalValue(new BigDecimal("160000.00")); // 100 shares * 1600
+        execution.setMarginDeployed(new BigDecimal("32000.00")); // 20% margin
+    }
+
+    // ── Test 1: SL hit for LONG position (LTP <= stopLoss) → exit triggered ──
+    @Test
+    void testStopLossHitForLongPosition() {
+        BigDecimal ltpBelowSl = new BigDecimal("1500.00"); // LTP == SL
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltpBelowSl);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        // Verify exit was triggered
+        ArgumentCaptor<TradeExecution> execCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(execCaptor.capture());
+        assertEquals(ExitReason.STOP_HIT, execCaptor.getValue().getExitReason());
+        assertEquals(ltpBelowSl, execCaptor.getValue().getExitPriceActual());
+
+        // Verify signal marked COMPLETED
+        ArgumentCaptor<TradeSignal> signalCaptor = ArgumentCaptor.forClass(TradeSignal.class);
+        verify(signalRepository).save(signalCaptor.capture());
+        assertEquals(TradeStatus.COMPLETED, signalCaptor.getValue().getStatus());
+
+        // Verify exit order created (dry-run format)
+        assertTrue(execCaptor.getValue().getExitOrderId().contains("DRY-RUN-EXIT"));
+
+        verify(tradeOrchestrationService).onExitTriggered(signal, ExitReason.STOP_HIT);
+    }
+
+    // ── Test 2: SL hit for SHORT position (LTP >= stopLoss) → exit triggered ──
+    @Test
+    void testStopLossHitForShortPosition() {
+        signal.setDirection(TradeDirection.SHORT);
+        signal.setStopLoss(new BigDecimal("1700.00"));
+        signal.setTarget(new BigDecimal("1500.00"));
+
+        BigDecimal ltpAboveSl = new BigDecimal("1700.00"); // LTP == SL for SHORT
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltpAboveSl);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        // Verify exit triggered with STOP_HIT reason
+        ArgumentCaptor<TradeExecution> execCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(execCaptor.capture());
+        assertEquals(ExitReason.STOP_HIT, execCaptor.getValue().getExitReason());
+
+        verify(tradeOrchestrationService).onExitTriggered(signal, ExitReason.STOP_HIT);
+    }
+
+    // ── Test 3: Target hit for LONG (LTP >= target) → exit triggered ──
+    @Test
+    void testTargetHitForLongPosition() {
+        BigDecimal ltpAtTarget = new BigDecimal("1700.00"); // LTP == target
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltpAtTarget);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        // Verify exit triggered with TARGET_HIT reason
+        ArgumentCaptor<TradeExecution> execCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(execCaptor.capture());
+        assertEquals(ExitReason.TARGET_HIT, execCaptor.getValue().getExitReason());
+
+        verify(tradeOrchestrationService).onExitTriggered(signal, ExitReason.TARGET_HIT);
+    }
+
+    // ── Test 4: Target hit for SHORT (LTP <= target) → exit triggered ──
+    @Test
+    void testTargetHitForShortPosition() {
+        signal.setDirection(TradeDirection.SHORT);
+        signal.setStopLoss(new BigDecimal("1700.00"));
+        signal.setTarget(new BigDecimal("1500.00"));
+
+        BigDecimal ltpAtTarget = new BigDecimal("1500.00"); // LTP == target for SHORT
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltpAtTarget);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        // Verify exit triggered with TARGET_HIT reason
+        ArgumentCaptor<TradeExecution> execCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(execCaptor.capture());
+        assertEquals(ExitReason.TARGET_HIT, execCaptor.getValue().getExitReason());
+
+        verify(tradeOrchestrationService).onExitTriggered(signal, ExitReason.TARGET_HIT);
+    }
+
+    // ── Test 5: HOLD — price between SL and target, no exit ──
+    @Test
+    void testHoldWhenPriceBetweenSlAndTarget() {
+        BigDecimal ltpBetween = new BigDecimal("1600.00"); // Between SL(1500) and Target(1700)
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltpBetween);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        // Verify exit was NOT triggered
+        verify(tradeOrchestrationService, never()).onExitTriggered(any(), any());
+
+        // Verify monitoring log written
+        verify(logRepository).save(any(TradeMonitorLog.class));
+
+        // Verify signal is still ACTIVE (not transitioned)
+        verify(signalRepository, never()).save(argThat(s -> s.getStatus() == TradeStatus.COMPLETED));
+    }
+
+    // ── Test 6: LTP fetch failure — skip tick, no crash ──
+    @Test
+    void testLtpFetchFailureSkipsTick() {
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(null);
+
+        handler.handle(signal, true);
+
+        // Verify no exit triggered
+        verify(executionRepository, never()).save(any(TradeExecution.class));
+        verify(signalRepository, never()).save(any(TradeSignal.class));
+
+        // Verify monitor log created with NONE action
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        assertEquals(MonitorAction.NONE, logCaptor.getValue().getActionTaken());
+        assertTrue(logCaptor.getValue().getActionDetail().contains("LTP unavailable"));
+    }
+
+    // ── Test 7: No execution found for signal → log ERROR, return ──
+    @Test
+    void testNoExecutionFoundLogsError() {
+        BigDecimal ltp = new BigDecimal("1600.00");
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltp);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.empty());
+
+        handler.handle(signal, true);
+
+        // Verify error log written
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        assertEquals(MonitorAction.ERROR, logCaptor.getValue().getActionTaken());
+        assertTrue(logCaptor.getValue().getActionDetail().contains("No execution record found"));
+
+        // Verify no exit triggered
+        verify(tradeOrchestrationService, never()).onExitTriggered(any(), any());
+    }
+
+    // ── Test 8a: P&L calculation — LONG win ──
+    @Test
+    void testPnlCalculationLongWin() {
+        BigDecimal exitPrice = new BigDecimal("1700.00"); // +100 per share
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(exitPrice);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        ArgumentCaptor<TradeExecution> execCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(execCaptor.capture());
+        TradeExecution result = execCaptor.getValue();
+
+        // Expected: 100 shares * 100 = 10,000 gross
+        BigDecimal expectedGrossA = new BigDecimal("10000.00");
+        assertEquals(expectedGrossA, result.getGrossPnlInr());
+
+        // Expected: 10,000 - 1,500 brokerage = 8,500 net
+        BigDecimal expectedNetPnl = new BigDecimal("8500.00");
+        assertEquals(expectedNetPnl, result.getNetPnlInr());
+
+        // Expected: 8,500 / 32,000 * 100 = 26.56%
+        BigDecimal expectedNetPct = new BigDecimal("26.56");
+        assertTrue(result.getNetPnlPct().compareTo(expectedNetPct) >= 0); // Allow rounding
+        assertTrue(result.getNetPnlPct().compareTo(expectedNetPct.add(BigDecimal.ONE)) <= 0);
+    }
+
+    // ── Test 8b: P&L calculation — LONG loss (hits SL) ──
+    @Test
+    void testPnlCalculationLongLoss() {
+        BigDecimal exitPrice = new BigDecimal("1499.00"); // Below SL(1500), triggers stop loss
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(exitPrice);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        ArgumentCaptor<TradeExecution> execCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(execCaptor.capture());
+        TradeExecution result = execCaptor.getValue();
+
+        // Expected: 100 shares * -101 = -10,100 gross
+        BigDecimal expectedGross = new BigDecimal("-10100.00");
+        assertEquals(expectedGross, result.getGrossPnlInr());
+
+        // Expected: -10,100 - 1,500 brokerage = -11,600 net
+        BigDecimal expectedNetPnl = new BigDecimal("-11600.00");
+        assertEquals(expectedNetPnl, result.getNetPnlInr());
+
+        // Expected: -11,600 / 32,000 * 100 = -36.25% (loss)
+        assertTrue(result.getNetPnlPct().signum() < 0); // Negative P&L
+    }
+
+    // ── Test 8c: P&L calculation — SHORT win ──
+    @Test
+    void testPnlCalculationShortWin() {
+        signal.setDirection(TradeDirection.SHORT);
+        signal.setStopLoss(new BigDecimal("1700.00"));
+        signal.setTarget(new BigDecimal("1500.00"));
+
+        BigDecimal exitPrice = new BigDecimal("1500.00"); // Short hits target (at or below)
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(exitPrice);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        ArgumentCaptor<TradeExecution> execCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(execCaptor.capture());
+        TradeExecution result = execCaptor.getValue();
+
+        // SHORT: move = (1500-1600)/1600 = -6.25% → negated = +6.25%
+        // Gross = 160000 * 0.0625 = 10000
+        BigDecimal expectedGross = new BigDecimal("10000.00");
+        assertEquals(expectedGross, result.getGrossPnlInr());
+
+        // Net = 10000 - 1500 = 8500
+        BigDecimal expectedNetPnl = new BigDecimal("8500.00");
+        assertEquals(expectedNetPnl, result.getNetPnlInr());
+
+        assertTrue(result.getNetPnlPct().signum() > 0); // Positive P&L
+    }
+
+    // ── Test 8d: P&L calculation — SHORT loss ──
+    @Test
+    void testPnlCalculationShortLoss() {
+        signal.setDirection(TradeDirection.SHORT);
+        signal.setStopLoss(new BigDecimal("1700.00"));
+        signal.setTarget(new BigDecimal("1500.00"));
+
+        BigDecimal exitPrice = new BigDecimal("1700.00"); // Short exits higher = loss (SL hit)
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(exitPrice);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        ArgumentCaptor<TradeExecution> execCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(execCaptor.capture());
+        TradeExecution result = execCaptor.getValue();
+
+        // SHORT: move = (1700-1600)/1600 = 6.25% → negated = -6.25%
+        // Gross = 160000 * -0.0625 = -10000
+        BigDecimal expectedGross = new BigDecimal("-10000.00");
+        assertEquals(expectedGross, result.getGrossPnlInr());
+
+        // Net = -10000 - 1500 = -11500
+        BigDecimal expectedNetPnl = new BigDecimal("-11500.00");
+        assertEquals(expectedNetPnl, result.getNetPnlInr());
+
+        assertTrue(result.getNetPnlPct().signum() < 0); // Negative P&L
+    }
+
+    // ── Test 9: Dry-run exit — creates DRY-RUN order ID, sets signal COMPLETED ──
+    @Test
+    void testDryRunExitCreatesOrderIdAndMarksCompleted() {
+        ReflectionTestUtils.setField(handler, "dryRun", true);
+        BigDecimal exitPrice = new BigDecimal("1700.00");
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(exitPrice);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        ArgumentCaptor<TradeExecution> execCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository, atLeast(1)).save(execCaptor.capture());
+        TradeExecution saved = execCaptor.getValue();
+
+        // Verify DRY-RUN order ID
+        assertTrue(saved.getExitOrderId().startsWith("DRY-RUN-EXIT-"));
+        assertTrue(saved.getExitOrderId().contains("1")); // Signal ID
+
+        // Verify exit time set
+        assertNotNull(saved.getExitTime());
+
+        // Verify signal marked COMPLETED
+        ArgumentCaptor<TradeSignal> signalCaptor = ArgumentCaptor.forClass(TradeSignal.class);
+        verify(signalRepository).save(signalCaptor.capture());
+        assertEquals(TradeStatus.COMPLETED, signalCaptor.getValue().getStatus());
+    }
+
+    // ── Test 10: ExitStrategy for IMPULSE type — delegates to ExitStrategyRouter ──
+    @Test
+    void testImpulseExitStrategyDelegation() {
+        signal.setStrategyType(StrategyType.IMPULSE);
+        signal.setStochRsiK(new BigDecimal("70.00"));
+        signal.setRrRatio(new BigDecimal("2.00"));
+
+        BigDecimal ltp = new BigDecimal("1650.00");
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltp);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        // Mock strategy returns EXIT decision
+        ExitStrategy mockStrategy = mock(ExitStrategy.class);
+        when(exitStrategyRouter.getStrategy(StrategyType.IMPULSE)).thenReturn(mockStrategy);
+        when(mockStrategy.evaluate(signal, ltp, ltp))
+                .thenReturn(ExitDecision.exit(ExitReason.TARGET_HIT, ltp));
+
+        handler.handle(signal, true);
+
+        // Verify strategy was consulted
+        verify(exitStrategyRouter).getStrategy(StrategyType.IMPULSE);
+        verify(mockStrategy).evaluate(signal, ltp, ltp);
+
+        // Verify exit was triggered
+        verify(tradeOrchestrationService).onExitTriggered(signal, ExitReason.TARGET_HIT);
+    }
+
+    // ── Test 11: IMPULSE UPDATE_SLAB action advances slab and logs ──
+    @Test
+    void testImpulseUpdateSlabAction() {
+        signal.setStrategyType(StrategyType.IMPULSE);
+        signal.setStopLoss(new BigDecimal("1500.00"));
+
+        BigDecimal ltp = new BigDecimal("1650.00");
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltp);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        ExitStrategy mockStrategy = mock(ExitStrategy.class);
+        when(exitStrategyRouter.getStrategy(StrategyType.IMPULSE)).thenReturn(mockStrategy);
+        when(mockStrategy.evaluate(signal, ltp, ltp))
+                .thenReturn(ExitDecision.updateSlab(1));
+
+        handler.handle(signal, true);
+
+        // Verify slab was logged
+        verify(tradeActionLogger).logSlab(eq(signal), eq(1), eq(ltp), any(BigDecimal.class));
+
+        // Verify signal was saved (slab update)
+        verify(signalRepository).save(signal);
+
+        // Verify monitoring log written
+        verify(logRepository).save(any(TradeMonitorLog.class));
+
+        // Verify NO exit triggered
+        verify(tradeOrchestrationService, never()).onExitTriggered(any(), any());
+    }
+
+    // ── Test 12: IMPULSE HOLD action logs monitoring, no exit ──
+    @Test
+    void testImpulseHoldAction() {
+        signal.setStrategyType(StrategyType.IMPULSE);
+
+        BigDecimal ltp = new BigDecimal("1650.00");
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltp);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        ExitStrategy mockStrategy = mock(ExitStrategy.class);
+        when(exitStrategyRouter.getStrategy(StrategyType.IMPULSE)).thenReturn(mockStrategy);
+        when(mockStrategy.evaluate(signal, ltp, ltp))
+                .thenReturn(ExitDecision.hold());
+
+        handler.handle(signal, true);
+
+        // Verify monitoring log written
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        assertEquals(MonitorAction.NONE, logCaptor.getValue().getActionTaken());
+        assertTrue(logCaptor.getValue().getActionDetail().contains("Impulse monitoring"));
+
+        // Verify NO exit triggered
+        verify(tradeOrchestrationService, never()).onExitTriggered(any(), any());
+    }
+
+    // ── Test 13: Live mode exit places order, marks EXIT_PENDING ──
+    @Test
+    void testLiveExitPlacesOrderAndMarksPending() {
+        ReflectionTestUtils.setField(handler, "dryRun", false);
+        BigDecimal exitPrice = new BigDecimal("1700.00");
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(exitPrice);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+        when(brokerOrderService.placeExitOrder(signal, execution)).thenReturn("ORD-12345");
+
+        handler.handle(signal, false);
+
+        // Verify order was placed
+        verify(brokerOrderService).placeExitOrder(signal, execution);
+
+        // Verify execution saved with order ID and reason
+        ArgumentCaptor<TradeExecution> execCaptor = ArgumentCaptor.forClass(TradeExecution.class);
+        verify(executionRepository).save(execCaptor.capture());
+        assertEquals("ORD-12345", execCaptor.getValue().getExitOrderId());
+        assertEquals(ExitReason.TARGET_HIT, execCaptor.getValue().getExitReason());
+
+        // Verify signal marked EXIT_PENDING (not COMPLETED)
+        ArgumentCaptor<TradeSignal> signalCaptor = ArgumentCaptor.forClass(TradeSignal.class);
+        verify(signalRepository).save(signalCaptor.capture());
+        assertEquals(TradeStatus.EXIT_PENDING, signalCaptor.getValue().getStatus());
+
+        // Verify orchestration service NOT called (live mode)
+        verify(tradeOrchestrationService, never()).onExitTriggered(any(), any());
+    }
+
+    // ── Test 14: checkFill in dry-run immediately completes signal ──
+    @Test
+    void testCheckFillInDryRunCompletesImmediately() {
+        signal.setStatus(TradeStatus.EXIT_PENDING);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.checkFill(signal, true);
+
+        // Verify signal transitioned to COMPLETED
+        ArgumentCaptor<TradeSignal> signalCaptor = ArgumentCaptor.forClass(TradeSignal.class);
+        verify(signalRepository).save(signalCaptor.capture());
+        assertEquals(TradeStatus.COMPLETED, signalCaptor.getValue().getStatus());
+    }
+
+    // ── Test 15: Unrealised P&L calculation for LONG position ──
+    @Test
+    void testUnrealisedPnlForLongPosition() {
+        BigDecimal ltp = new BigDecimal("1650.00"); // +50 profit per share
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltp);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        TradeMonitorLog log = logCaptor.getValue();
+
+        // Verify unrealised P&L: 160000 * (1650-1600)/1600 = 160000 * 0.03125 = 5000
+        BigDecimal expectedUnrealisedPnl = new BigDecimal("5000.00");
+        assertEquals(expectedUnrealisedPnl, log.getUnrealisedPnlInr());
+    }
+
+    // ── Test 16: Unrealised P&L calculation for SHORT position ──
+    @Test
+    void testUnrealisedPnlForShortPosition() {
+        signal.setDirection(TradeDirection.SHORT);
+        signal.setStopLoss(new BigDecimal("1700.00"));
+        signal.setTarget(new BigDecimal("1500.00"));
+
+        BigDecimal ltp = new BigDecimal("1550.00"); // Short profit = exit lower
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltp);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        TradeMonitorLog log = logCaptor.getValue();
+
+        // SHORT: move = (1550-1600)/1600 → negate → 3.125%
+        // unrealised = 160000 * 0.03125 = 5000
+        BigDecimal expectedUnrealisedPnl = new BigDecimal("5000.00");
+        assertEquals(expectedUnrealisedPnl, log.getUnrealisedPnlInr());
+    }
+
+    // ── Test 17: Action logger called with correct exit action ──
+    @Test
+    void testActionLoggerCalledWithStopHit() {
+        BigDecimal exitPrice = new BigDecimal("1500.00");
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(exitPrice);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        ArgumentCaptor<TradeActionLog.TradeAction> actionCaptor =
+                ArgumentCaptor.forClass(TradeActionLog.TradeAction.class);
+        verify(tradeActionLogger).logWithPnl(eq(signal), actionCaptor.capture(), any(), any(), any());
+        assertEquals(TradeActionLog.TradeAction.STOP_HIT, actionCaptor.getValue());
+    }
+
+    // ── Test 18: Action logger called with TARGET_HIT ──
+    @Test
+    void testActionLoggerCalledWithTargetHit() {
+        BigDecimal exitPrice = new BigDecimal("1700.00");
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(exitPrice);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        ArgumentCaptor<TradeActionLog.TradeAction> actionCaptor =
+                ArgumentCaptor.forClass(TradeActionLog.TradeAction.class);
+        verify(tradeActionLogger).logWithPnl(eq(signal), actionCaptor.capture(), any(), any(), any());
+        assertEquals(TradeActionLog.TradeAction.TARGET_HIT, actionCaptor.getValue());
+    }
+
+    // ── Test 19: Monitor log includes unrealised P&L percentage ──
+    @Test
+    void testMonitorLogIncludesUnrealisedPnlPercentage() {
+        BigDecimal ltp = new BigDecimal("1650.00");
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltp);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        TradeMonitorLog log = logCaptor.getValue();
+
+        // Verify P&L% calculated: 5000 / 32000 * 100 = 15.625%
+        assertNotNull(log.getUnrealisedPnlPct());
+        assertTrue(log.getUnrealisedPnlPct().compareTo(BigDecimal.ZERO) > 0);
+    }
+
+    // ── Test 20: Null notional value doesn't crash P&L calculation ──
+    @Test
+    void testNullNotionalValueHandled() {
+        execution.setNotionalValue(null);
+        BigDecimal ltp = new BigDecimal("1650.00");
+        when(brokerOrderService.fetchLtp("HDFCBANK", 100L)).thenReturn(ltp);
+        when(executionRepository.findBySignal(signal)).thenReturn(Optional.of(execution));
+
+        handler.handle(signal, true);
+
+        // Verify monitor log written (no crash)
+        ArgumentCaptor<TradeMonitorLog> logCaptor = ArgumentCaptor.forClass(TradeMonitorLog.class);
+        verify(logRepository).save(logCaptor.capture());
+        TradeMonitorLog log = logCaptor.getValue();
+
+        // Unrealised P&L should be zero
+        assertEquals(BigDecimal.ZERO, log.getUnrealisedPnlInr());
+    }
+}

--- a/src/test/java/com/dtech/kitecon/trade/service/TradeOrchestrationServiceTest.java
+++ b/src/test/java/com/dtech/kitecon/trade/service/TradeOrchestrationServiceTest.java
@@ -3,6 +3,7 @@ package com.dtech.kitecon.trade.service;
 import com.dtech.kitecon.trade.dto.QuoteResult;
 import com.dtech.kitecon.trade.dto.ResolvedInstrument;
 import com.dtech.kitecon.trade.entity.SegmentConfig;
+import com.dtech.kitecon.trade.entity.TradeActionLog;
 import com.dtech.kitecon.trade.entity.TradeOrder;
 import com.dtech.kitecon.trade.entity.TradeSignal;
 import com.dtech.kitecon.trade.enums.*;
@@ -10,6 +11,7 @@ import com.dtech.kitecon.trade.repository.SegmentConfigRepository;
 import com.dtech.kitecon.trade.repository.TradeOrderRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -19,9 +21,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +42,9 @@ class TradeOrchestrationServiceTest {
 
     @Mock
     private TradeOrderRepository tradeOrderRepository;
+
+    @Mock
+    private TradeActionLogger tradeActionLogger;
 
     @InjectMocks
     private TradeOrchestrationService tradeOrchestrationService;
@@ -95,9 +99,9 @@ class TradeOrchestrationServiceTest {
                 .thenReturn(configs);
         when(marketQuoteService.getQuote(anyString(), any()))
                 .thenReturn(underlyingQuote);
-        when(instrumentResolverService.resolve("RELIANCE", TradingSegment.EQ, TradeDirection.LONG, BigDecimal.valueOf(2500)))
+        when(instrumentResolverService.resolve("RELIANCE", TradingSegment.EQ, TradeDirection.LONG, BigDecimal.valueOf(2500), 0.0))
                 .thenReturn(eqResolved);
-        when(instrumentResolverService.resolve("RELIANCE", TradingSegment.FUT, TradeDirection.LONG, BigDecimal.valueOf(2500)))
+        when(instrumentResolverService.resolve("RELIANCE", TradingSegment.FUT, TradeDirection.LONG, BigDecimal.valueOf(2500), 0.0))
                 .thenReturn(futResolved);
 
         tradeOrchestrationService.onEntryTriggered(signal);
@@ -175,6 +179,666 @@ class TradeOrchestrationServiceTest {
                 .thenReturn(Arrays.asList(order));
         when(marketQuoteService.getQuote("RELIANCE24JAN", 456L))
                 .thenReturn(null);
+
+        tradeOrchestrationService.onExitTriggered(signal, ExitReason.STOP_HIT);
+
+        verify(paperOrderExecutionService, never()).exit(any(), any(), any(), any());
+    }
+
+    // ============================================================================
+    // NEW TESTS: onEntryTriggered Safety-Net Coverage
+    // ============================================================================
+
+    @Test
+    void testOnEntryTriggered_MultipleSegmentConfigs_CreatesOrderForEach() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(1L)
+                .symbol("INFY")
+                .direction(TradeDirection.LONG)
+                .strategyType(StrategyType.DTB)
+                .instrumentToken(789L)
+                .build();
+
+        SegmentConfig eqConfig = SegmentConfig.builder()
+                .id(1L)
+                .symbol("INFY")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(1.0))
+                .build();
+
+        SegmentConfig ceConfig = SegmentConfig.builder()
+                .id(2L)
+                .symbol("INFY")
+                .segment(TradingSegment.OPT)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(1.5))
+                .build();
+
+        SegmentConfig peConfig = SegmentConfig.builder()
+                .id(3L)
+                .symbol("INFY")
+                .segment(TradingSegment.OPT)
+                .enabled(false) // Disabled, should not be processed
+                .capitalPct(BigDecimal.valueOf(1.5))
+                .build();
+
+        QuoteResult underlyingQuote = QuoteResult.builder()
+                .symbol("INFY")
+                .ltp(BigDecimal.valueOf(2200))
+                .askPrice(BigDecimal.valueOf(2201))
+                .bidPrice(BigDecimal.valueOf(2199))
+                .build();
+
+        ResolvedInstrument eqResolved = ResolvedInstrument.builder()
+                .tradingSymbol("INFY")
+                .instrumentToken(101L)
+                .instrumentType("EQ")
+                .lotSize(1)
+                .build();
+
+        ResolvedInstrument ceResolved = ResolvedInstrument.builder()
+                .tradingSymbol("INFY2500CE")
+                .instrumentToken(102L)
+                .instrumentType("CE")
+                .lotSize(600)
+                .build();
+
+        QuoteResult ceQuote = QuoteResult.builder()
+                .symbol("INFY2500CE")
+                .ltp(BigDecimal.valueOf(150))
+                .askPrice(BigDecimal.valueOf(151))
+                .bidPrice(BigDecimal.valueOf(149))
+                .build();
+
+        when(segmentConfigRepository.findBySymbolAndEnabledTrue("INFY"))
+                .thenReturn(Arrays.asList(eqConfig, ceConfig));
+        when(marketQuoteService.getQuote("INFY", 789L))
+                .thenReturn(underlyingQuote);
+        when(instrumentResolverService.resolve("INFY", TradingSegment.EQ, TradeDirection.LONG, BigDecimal.valueOf(2200), 0.0))
+                .thenReturn(eqResolved);
+        when(instrumentResolverService.resolve("INFY", TradingSegment.OPT, TradeDirection.LONG, BigDecimal.valueOf(2200), 0.0))
+                .thenReturn(ceResolved);
+        when(marketQuoteService.getQuote("INFY", 101L))
+                .thenReturn(underlyingQuote);
+        when(marketQuoteService.getQuote("INFY2500CE", 102L))
+                .thenReturn(ceQuote);
+
+        tradeOrchestrationService.onEntryTriggered(signal);
+
+        // Should create 2 orders (EQ and CE), skip PE (disabled)
+        verify(paperOrderExecutionService, times(2)).enter(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testOnEntryTriggered_UnderlyingQuoteUnavailable_SkipsSegmentContinuesToNext() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(2L)
+                .symbol("TCS")
+                .direction(TradeDirection.SHORT)
+                .strategyType(StrategyType.DTB)
+                .instrumentToken(501L)
+                .build();
+
+        SegmentConfig eqConfig = SegmentConfig.builder()
+                .id(4L)
+                .symbol("TCS")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(2.0))
+                .build();
+
+        SegmentConfig futConfig = SegmentConfig.builder()
+                .id(5L)
+                .symbol("TCS")
+                .segment(TradingSegment.FUT)
+                .enabled(true)
+                .capitalPct(BigDecimal.valueOf(2.0))
+                .build();
+
+        QuoteResult validQuote = QuoteResult.builder()
+                .symbol("TCS")
+                .ltp(BigDecimal.valueOf(3500))
+                .build();
+
+        ResolvedInstrument futResolved = ResolvedInstrument.builder()
+                .tradingSymbol("TCSFEB24")
+                .instrumentToken(502L)
+                .instrumentType("FUT")
+                .lotSize(1)
+                .build();
+
+        // First call returns null (underlying for EQ), second call returns quote (underlying for FUT)
+        when(marketQuoteService.getQuote("TCS", 501L))
+                .thenReturn(null) // First segment underlying quote unavailable
+                .thenReturn(validQuote); // Second segment underlying quote available
+
+        when(segmentConfigRepository.findBySymbolAndEnabledTrue("TCS"))
+                .thenReturn(Arrays.asList(eqConfig, futConfig));
+
+        when(instrumentResolverService.resolve("TCS", TradingSegment.FUT, TradeDirection.SHORT, BigDecimal.valueOf(3500), 0.0))
+                .thenReturn(futResolved);
+
+        when(marketQuoteService.getQuote("TCSFEB24", 502L))
+                .thenReturn(validQuote);
+
+        tradeOrchestrationService.onEntryTriggered(signal);
+
+        // Should skip EQ (no underlying quote) and still try FUT
+        verify(paperOrderExecutionService, times(1)).enter(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testOnEntryTriggered_InstrumentResolutionException_CatchesContinuesToNext() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(3L)
+                .symbol("HDFC")
+                .direction(TradeDirection.LONG)
+                .strategyType(StrategyType.DTB)
+                .instrumentToken(601L)
+                .build();
+
+        SegmentConfig eqConfig = SegmentConfig.builder()
+                .id(6L)
+                .symbol("HDFC")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .build();
+
+        SegmentConfig futConfig = SegmentConfig.builder()
+                .id(7L)
+                .symbol("HDFC")
+                .segment(TradingSegment.FUT)
+                .enabled(true)
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("HDFC")
+                .ltp(BigDecimal.valueOf(2800))
+                .build();
+
+        ResolvedInstrument futResolved = ResolvedInstrument.builder()
+                .tradingSymbol("HDFCFEB24")
+                .instrumentToken(603L)
+                .instrumentType("FUT")
+                .build();
+
+        QuoteResult futQuote = QuoteResult.builder()
+                .symbol("HDFCFEB24")
+                .ltp(BigDecimal.valueOf(2850))
+                .build();
+
+        when(segmentConfigRepository.findBySymbolAndEnabledTrue("HDFC"))
+                .thenReturn(Arrays.asList(eqConfig, futConfig));
+        when(marketQuoteService.getQuote("HDFC", 601L))
+                .thenReturn(quote);
+
+        // EQ resolution throws exception, FUT resolution succeeds
+        when(instrumentResolverService.resolve("HDFC", TradingSegment.EQ, TradeDirection.LONG, BigDecimal.valueOf(2800), 0.0))
+                .thenThrow(new RuntimeException("Instrument resolution failed for EQ"));
+
+        when(instrumentResolverService.resolve("HDFC", TradingSegment.FUT, TradeDirection.LONG, BigDecimal.valueOf(2800), 0.0))
+                .thenReturn(futResolved);
+
+        when(marketQuoteService.getQuote("HDFCFEB24", 603L))
+                .thenReturn(futQuote);
+
+        tradeOrchestrationService.onEntryTriggered(signal);
+
+        // Should skip EQ (exception) and continue to FUT
+        verify(paperOrderExecutionService, times(1)).enter(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testOnEntryTriggered_InstrumentQuoteUnavailable_SkipsSegment() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(4L)
+                .symbol("WIPRO")
+                .direction(TradeDirection.LONG)
+                .strategyType(StrategyType.DTB)
+                .instrumentToken(701L)
+                .build();
+
+        SegmentConfig ceConfig = SegmentConfig.builder()
+                .id(8L)
+                .symbol("WIPRO")
+                .segment(TradingSegment.OPT)
+                .enabled(true)
+                .build();
+
+        QuoteResult underlyingQuote = QuoteResult.builder()
+                .symbol("WIPRO")
+                .ltp(BigDecimal.valueOf(450))
+                .build();
+
+        ResolvedInstrument ceResolved = ResolvedInstrument.builder()
+                .tradingSymbol("WIPRO500CE")
+                .instrumentToken(702L)
+                .instrumentType("CE")
+                .build();
+
+        when(segmentConfigRepository.findBySymbolAndEnabledTrue("WIPRO"))
+                .thenReturn(Arrays.asList(ceConfig));
+        when(marketQuoteService.getQuote("WIPRO", 701L))
+                .thenReturn(underlyingQuote);
+        when(instrumentResolverService.resolve("WIPRO", TradingSegment.OPT, TradeDirection.LONG, BigDecimal.valueOf(450), 0.0))
+                .thenReturn(ceResolved);
+
+        // Instrument quote not available
+        when(marketQuoteService.getQuote("WIPRO500CE", 702L))
+                .thenReturn(null);
+
+        tradeOrchestrationService.onEntryTriggered(signal);
+
+        // Should skip segment due to missing instrument quote
+        verify(paperOrderExecutionService, never()).enter(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testOnEntryTriggered_PaperOrderEntryException_CatchesAndContinues() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(5L)
+                .symbol("BAJAJ")
+                .direction(TradeDirection.SHORT)
+                .strategyType(StrategyType.DTB)
+                .instrumentToken(801L)
+                .build();
+
+        SegmentConfig eqConfig = SegmentConfig.builder()
+                .id(9L)
+                .symbol("BAJAJ")
+                .segment(TradingSegment.EQ)
+                .enabled(true)
+                .build();
+
+        SegmentConfig futConfig = SegmentConfig.builder()
+                .id(10L)
+                .symbol("BAJAJ")
+                .segment(TradingSegment.FUT)
+                .enabled(true)
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("BAJAJ")
+                .ltp(BigDecimal.valueOf(1800))
+                .build();
+
+        ResolvedInstrument eqResolved = ResolvedInstrument.builder()
+                .tradingSymbol("BAJAJ")
+                .instrumentToken(802L)
+                .instrumentType("EQ")
+                .build();
+
+        ResolvedInstrument futResolved = ResolvedInstrument.builder()
+                .tradingSymbol("BAJAJFEB24")
+                .instrumentToken(803L)
+                .instrumentType("FUT")
+                .build();
+
+        when(segmentConfigRepository.findBySymbolAndEnabledTrue("BAJAJ"))
+                .thenReturn(Arrays.asList(eqConfig, futConfig));
+        when(marketQuoteService.getQuote("BAJAJ", 801L))
+                .thenReturn(quote);
+        when(instrumentResolverService.resolve("BAJAJ", TradingSegment.EQ, TradeDirection.SHORT, BigDecimal.valueOf(1800), 0.0))
+                .thenReturn(eqResolved);
+        when(instrumentResolverService.resolve("BAJAJ", TradingSegment.FUT, TradeDirection.SHORT, BigDecimal.valueOf(1800), 0.0))
+                .thenReturn(futResolved);
+        when(marketQuoteService.getQuote("BAJAJ", 802L))
+                .thenReturn(quote);
+        when(marketQuoteService.getQuote("BAJAJFEB24", 803L))
+                .thenReturn(quote);
+
+        // EQ order entry throws exception, FUT succeeds
+        doThrow(new RuntimeException("Order placement failed"))
+                .when(paperOrderExecutionService).enter(any(), eq(eqConfig), any(), any(), any());
+
+        tradeOrchestrationService.onEntryTriggered(signal);
+
+        // Should attempt both EQ and FUT despite EQ failure
+        ArgumentCaptor<SegmentConfig> configCaptor = ArgumentCaptor.forClass(SegmentConfig.class);
+        verify(paperOrderExecutionService, times(2)).enter(any(), configCaptor.capture(), any(), any(), any());
+        // Verify that despite exception on EQ, FUT was still attempted
+        assertTrue(configCaptor.getAllValues().stream().anyMatch(c -> c.getSegment() == TradingSegment.FUT),
+                "FUT should still be attempted after EQ failure");
+    }
+
+    @Test
+    void testOnEntryTriggered_ImpulseStrategyUsesOtmOffset() {
+        TradeSignal impulseSignal = TradeSignal.builder()
+                .id(6L)
+                .symbol("SBIN")
+                .direction(TradeDirection.LONG)
+                .strategyType(StrategyType.IMPULSE)
+                .instrumentToken(901L)
+                .build();
+
+        SegmentConfig ceConfig = SegmentConfig.builder()
+                .id(11L)
+                .symbol("SBIN")
+                .segment(TradingSegment.OPT)
+                .enabled(true)
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("SBIN")
+                .ltp(BigDecimal.valueOf(600))
+                .build();
+
+        ResolvedInstrument ceResolved = ResolvedInstrument.builder()
+                .tradingSymbol("SBIN618CE")
+                .instrumentToken(902L)
+                .instrumentType("CE")
+                .build();
+
+        QuoteResult ceQuote = QuoteResult.builder()
+                .symbol("SBIN618CE")
+                .ltp(BigDecimal.valueOf(50))
+                .build();
+
+        when(segmentConfigRepository.findBySymbolAndEnabledTrue("SBIN"))
+                .thenReturn(Arrays.asList(ceConfig));
+        when(marketQuoteService.getQuote("SBIN", 901L))
+                .thenReturn(quote);
+        when(marketQuoteService.getQuote("SBIN618CE", 902L))
+                .thenReturn(ceQuote);
+
+        ArgumentCaptor<Double> otmCaptor = ArgumentCaptor.forClass(Double.class);
+        when(instrumentResolverService.resolve(eq("SBIN"), eq(TradingSegment.OPT), eq(TradeDirection.LONG),
+                eq(BigDecimal.valueOf(600)), otmCaptor.capture()))
+                .thenReturn(ceResolved);
+
+        tradeOrchestrationService.onEntryTriggered(impulseSignal);
+
+        // Verify OTM offset of 0.03 for IMPULSE strategy
+        assertEquals(0.03, otmCaptor.getValue(), "IMPULSE strategy should use 0.03 OTM offset");
+        verify(paperOrderExecutionService, times(1)).enter(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testOnEntryTriggered_NonImpulseStrategyUsesZeroOtm() {
+        TradeSignal dtbSignal = TradeSignal.builder()
+                .id(7L)
+                .symbol("MARUTI")
+                .direction(TradeDirection.SHORT)
+                .strategyType(StrategyType.DTB)
+                .instrumentToken(1001L)
+                .build();
+
+        SegmentConfig ceConfig = SegmentConfig.builder()
+                .id(12L)
+                .symbol("MARUTI")
+                .segment(TradingSegment.OPT)
+                .enabled(true)
+                .build();
+
+        QuoteResult quote = QuoteResult.builder()
+                .symbol("MARUTI")
+                .ltp(BigDecimal.valueOf(7500))
+                .build();
+
+        ResolvedInstrument ceResolved = ResolvedInstrument.builder()
+                .tradingSymbol("MARUTI7500CE")
+                .instrumentToken(1002L)
+                .instrumentType("CE")
+                .build();
+
+        QuoteResult ceQuote = QuoteResult.builder()
+                .symbol("MARUTI7500CE")
+                .ltp(BigDecimal.valueOf(100))
+                .build();
+
+        when(segmentConfigRepository.findBySymbolAndEnabledTrue("MARUTI"))
+                .thenReturn(Arrays.asList(ceConfig));
+        when(marketQuoteService.getQuote("MARUTI", 1001L))
+                .thenReturn(quote);
+        when(marketQuoteService.getQuote("MARUTI7500CE", 1002L))
+                .thenReturn(ceQuote);
+
+        ArgumentCaptor<Double> otmCaptor = ArgumentCaptor.forClass(Double.class);
+        when(instrumentResolverService.resolve(eq("MARUTI"), eq(TradingSegment.OPT), eq(TradeDirection.SHORT),
+                eq(BigDecimal.valueOf(7500)), otmCaptor.capture()))
+                .thenReturn(ceResolved);
+
+        tradeOrchestrationService.onEntryTriggered(dtbSignal);
+
+        // Verify OTM offset of 0.0 for non-IMPULSE strategy
+        assertEquals(0.0, otmCaptor.getValue(), "Non-IMPULSE strategy should use 0.0 OTM offset");
+        verify(paperOrderExecutionService, times(1)).enter(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void testOnEntryTriggered_NoSegmentConfigs_ReturnsImmediately() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(8L)
+                .symbol("UNKNOWN")
+                .direction(TradeDirection.LONG)
+                .instrumentToken(1101L)
+                .build();
+
+        when(segmentConfigRepository.findBySymbolAndEnabledTrue("UNKNOWN"))
+                .thenReturn(Collections.emptyList());
+
+        tradeOrchestrationService.onEntryTriggered(signal);
+
+        // Should not call any service methods
+        verify(marketQuoteService, never()).getQuote(anyString(), any());
+        verify(instrumentResolverService, never()).resolve(anyString(), any(), any(), any(), anyDouble());
+        verify(paperOrderExecutionService, never()).enter(any(), any(), any(), any(), any());
+    }
+
+    // ============================================================================
+    // NEW TESTS: onExitTriggered Safety-Net Coverage
+    // ============================================================================
+
+    @Test
+    void testOnExitTriggered_MultipleOpenOrders_ExitsEach() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(9L)
+                .symbol("ICICI")
+                .build();
+
+        TradeOrder order1 = TradeOrder.builder()
+                .id(101L)
+                .symbol("ICICI25AUG500CE")
+                .instrumentToken(1201L)
+                .underlyingSymbol("ICICI")
+                .entryPrice(BigDecimal.valueOf(50))
+                .direction(TradeDirection.LONG)
+                .quantity(100)
+                .status(TradeOrderStatus.OPEN)
+                .build();
+
+        TradeOrder order2 = TradeOrder.builder()
+                .id(102L)
+                .symbol("ICICI25AUG520CE")
+                .instrumentToken(1202L)
+                .underlyingSymbol("ICICI")
+                .entryPrice(BigDecimal.valueOf(30))
+                .direction(TradeDirection.LONG)
+                .quantity(100)
+                .status(TradeOrderStatus.OPEN)
+                .build();
+
+        QuoteResult quote1 = QuoteResult.builder()
+                .symbol("ICICI25AUG500CE")
+                .ltp(BigDecimal.valueOf(75))
+                .build();
+
+        QuoteResult quote2 = QuoteResult.builder()
+                .symbol("ICICI25AUG520CE")
+                .ltp(BigDecimal.valueOf(40))
+                .build();
+
+        QuoteResult underlyingQuote = QuoteResult.builder()
+                .symbol("ICICI")
+                .ltp(BigDecimal.valueOf(575))
+                .build();
+
+        when(tradeOrderRepository.findBySignalAndStatus(signal, TradeOrderStatus.OPEN))
+                .thenReturn(Arrays.asList(order1, order2));
+        when(marketQuoteService.getQuote("ICICI25AUG500CE", 1201L))
+                .thenReturn(quote1);
+        when(marketQuoteService.getQuote("ICICI25AUG520CE", 1202L))
+                .thenReturn(quote2);
+        when(marketQuoteService.getQuote("ICICI", null))
+                .thenReturn(underlyingQuote);
+
+        tradeOrchestrationService.onExitTriggered(signal, ExitReason.TARGET_HIT);
+
+        verify(paperOrderExecutionService, times(2)).exit(any(), any(), any(), any());
+    }
+
+    @Test
+    void testOnExitTriggered_OrderQuoteUnavailableAtExit_OrderStaysOpen() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(10L)
+                .symbol("AXIS")
+                .build();
+
+        TradeOrder order = TradeOrder.builder()
+                .id(103L)
+                .symbol("AXIS25OCT900CE")
+                .instrumentToken(1301L)
+                .underlyingSymbol("AXIS")
+                .entryPrice(BigDecimal.valueOf(60))
+                .direction(TradeDirection.LONG)
+                .quantity(50)
+                .status(TradeOrderStatus.OPEN)
+                .build();
+
+        when(tradeOrderRepository.findBySignalAndStatus(signal, TradeOrderStatus.OPEN))
+                .thenReturn(Arrays.asList(order));
+        when(marketQuoteService.getQuote("AXIS25OCT900CE", 1301L))
+                .thenReturn(null); // Quote unavailable
+
+        tradeOrchestrationService.onExitTriggered(signal, ExitReason.STOP_HIT);
+
+        // Should not exit when quote is unavailable
+        verify(paperOrderExecutionService, never()).exit(any(), any(), any(), any());
+    }
+
+    @Test
+    void testOnExitTriggered_PaperOrderExitException_CatchesContinues() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(11L)
+                .symbol("KOTAK")
+                .build();
+
+        TradeOrder order1 = TradeOrder.builder()
+                .id(104L)
+                .symbol("KOTAKFEB24CE")
+                .instrumentToken(1401L)
+                .underlyingSymbol("KOTAK")
+                .entryPrice(BigDecimal.valueOf(100))
+                .direction(TradeDirection.LONG)
+                .quantity(25)
+                .status(TradeOrderStatus.OPEN)
+                .build();
+
+        TradeOrder order2 = TradeOrder.builder()
+                .id(105L)
+                .symbol("KOTAKFEB24PE")
+                .instrumentToken(1402L)
+                .underlyingSymbol("KOTAK")
+                .entryPrice(BigDecimal.valueOf(80))
+                .direction(TradeDirection.SHORT)
+                .quantity(25)
+                .status(TradeOrderStatus.OPEN)
+                .build();
+
+        QuoteResult ceQuote = QuoteResult.builder()
+                .symbol("KOTAKFEB24CE")
+                .ltp(BigDecimal.valueOf(120))
+                .build();
+
+        QuoteResult peQuote = QuoteResult.builder()
+                .symbol("KOTAKFEB24PE")
+                .ltp(BigDecimal.valueOf(70))
+                .build();
+
+        QuoteResult underlyingQuote = QuoteResult.builder()
+                .symbol("KOTAK")
+                .ltp(BigDecimal.valueOf(1200))
+                .build();
+
+        when(tradeOrderRepository.findBySignalAndStatus(signal, TradeOrderStatus.OPEN))
+                .thenReturn(Arrays.asList(order1, order2));
+        when(marketQuoteService.getQuote("KOTAKFEB24CE", 1401L))
+                .thenReturn(ceQuote);
+        when(marketQuoteService.getQuote("KOTAKFEB24PE", 1402L))
+                .thenReturn(peQuote);
+        when(marketQuoteService.getQuote("KOTAK", null))
+                .thenReturn(underlyingQuote);
+
+        // First exit throws exception
+        doThrow(new RuntimeException("Exit failed for order 1"))
+                .when(paperOrderExecutionService).exit(eq(order1), any(), any(), any());
+
+        tradeOrchestrationService.onExitTriggered(signal, ExitReason.REVERSAL_CANDLE);
+
+        // Should attempt to exit both despite first failure
+        ArgumentCaptor<TradeOrder> orderCaptor = ArgumentCaptor.forClass(TradeOrder.class);
+        verify(paperOrderExecutionService, times(2)).exit(orderCaptor.capture(), any(), any(), any());
+        // Verify both orders were attempted to be exited
+        assertTrue(orderCaptor.getAllValues().stream().anyMatch(o -> o.getId() == 104L),
+                "Order 1 should be attempted");
+        assertTrue(orderCaptor.getAllValues().stream().anyMatch(o -> o.getId() == 105L),
+                "Order 2 should still be attempted after order 1 failure");
+    }
+
+    @Test
+    void testOnExitTriggered_UnderlyingQuoteUnavailableAtExit_ContinuiesWithNullLtp() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(12L)
+                .symbol("HDFCBANK")
+                .build();
+
+        TradeOrder order = TradeOrder.builder()
+                .id(106L)
+                .symbol("HDFCBANKFEB24")
+                .instrumentToken(1501L)
+                .underlyingSymbol("HDFCBANK")
+                .entryPrice(BigDecimal.valueOf(1500))
+                .direction(TradeDirection.LONG)
+                .quantity(10)
+                .status(TradeOrderStatus.OPEN)
+                .build();
+
+        QuoteResult orderQuote = QuoteResult.builder()
+                .symbol("HDFCBANKFEB24")
+                .ltp(BigDecimal.valueOf(1550))
+                .build();
+
+        when(tradeOrderRepository.findBySignalAndStatus(signal, TradeOrderStatus.OPEN))
+                .thenReturn(Arrays.asList(order));
+        when(marketQuoteService.getQuote("HDFCBANKFEB24", 1501L))
+                .thenReturn(orderQuote);
+        when(marketQuoteService.getQuote("HDFCBANK", null))
+                .thenReturn(null); // Underlying quote unavailable
+
+        tradeOrchestrationService.onExitTriggered(signal, ExitReason.TARGET_HIT);
+
+        ArgumentCaptor<BigDecimal> underlyingLtpCaptor = ArgumentCaptor.forClass(BigDecimal.class);
+        verify(paperOrderExecutionService, times(1)).exit(
+                eq(order),
+                eq(orderQuote),
+                underlyingLtpCaptor.capture(),
+                eq(ExitReason.TARGET_HIT)
+        );
+
+        // Underlying LTP should be null when quote unavailable
+        assertNull(underlyingLtpCaptor.getValue(), "Underlying LTP should be null when quote unavailable");
+    }
+
+    @Test
+    void testOnExitTriggered_NoOpenOrders_DoesNothing() {
+        TradeSignal signal = TradeSignal.builder()
+                .id(13L)
+                .symbol("NOMURA")
+                .build();
+
+        when(tradeOrderRepository.findBySignalAndStatus(signal, TradeOrderStatus.OPEN))
+                .thenReturn(Collections.emptyList());
 
         tradeOrchestrationService.onExitTriggered(signal, ExitReason.STOP_HIT);
 


### PR DESCRIPTION
## Summary
78 safety-net unit tests for the trade execution critical path, pinning current behavior before refactoring.

### Test Coverage
| Class | Tests | Key Scenarios |
|-------|-------|---------------|
| TradeEntryHandlerTest | 12 | Entry triggers, ML filter, window expiry, dry/live mode |
| TradeExitHandlerTest | 23 | SL/target hit, P&L calc, IMPULSE strategy, slab updates |
| TradeOrchestrationServiceTest | 17 | Multi-segment, exception handling, quote unavailability |
| PaperOrderExecutionServiceTest | 15 | OPT direction, live orders, capital allocation |
| InstrumentResolverServiceTest | 11 | EQ/FUT/OPT resolution, BSE preference, strike selection |

### Details
- All tests use `@ExtendWith(MockitoExtension.class)` with `@Mock` — no Spring context boot
- Each test class runs in <2 seconds
- Fixed pre-existing test failures (findAll API migration)
- Edge cases: exception handling, null values, boundary conditions

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)