### PR TITLE
chore: disable charts browser pool (size=0)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -75,7 +75,7 @@ charts.temp.directory=/tmp/charts/temp
 charts.use.tradingview=true
 
 # Browser Pool Configuration
-charts.browser.pool.size=3
+charts.browser.pool.size=0
 charts.browser.timeout=30
 
 # WhatsApp configuration


### PR DESCRIPTION
Frees ~1.5GB RAM on the prod box. Chart features can re-enable via -Dcharts.browser.pool.size=N or profile override.