### PR TITLE
chore: add tradingsymbol indexes on instrument table (685× speedup)

### DIFF
--- a/src/main/java/com/dtech/kitecon/data/Instrument.java
+++ b/src/main/java/com/dtech/kitecon/data/Instrument.java
@@ -4,10 +4,17 @@ import java.time.LocalDateTime;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
 
 import lombok.*;
 
 @Entity
+@Table(indexes = {
+    @Index(name = "idx_tradingsymbol", columnList = "tradingsymbol"),
+    @Index(name = "idx_tradingsymbol_exchange", columnList = "tradingsymbol,exchange"),
+    @Index(name = "idx_tradingsymbol_expiry", columnList = "tradingsymbol,expiry")
+})
 @Data
 @Builder
 @AllArgsConstructor


### PR DESCRIPTION
Three indexes on the 346K-row instrument table to fix mysqld pegged at 93% CPU under live trading load. Already applied at runtime on prod via ALTER TABLE; this commit makes it persist.

Before: 137 ms / lookup × thousands of calls/min
After:  0.2 ms / lookup

🤖 Generated with [Claude Code](https://claude.com/claude-code)