### PR TITLE
feat: realised vs unrealised PnL split on trade-orders summary

### DIFF
--- a/src/main/java/com/dtech/kitecon/trade/controller/TradeOrderController.java
+++ b/src/main/java/com/dtech/kitecon/trade/controller/TradeOrderController.java
@@ -129,13 +129,13 @@ public class TradeOrderController {
         int openTrades = openOrders.size();
         int winCount = 0;
         int lossCount = 0;
-        BigDecimal totalPnl = BigDecimal.ZERO;
+        BigDecimal realisedPnl = BigDecimal.ZERO;
         BigDecimal totalWins = BigDecimal.ZERO;
         BigDecimal totalLosses = BigDecimal.ZERO;
 
         for (TradeOrder order : closedOrders) {
             if (order.getRealisedPnl() != null) {
-                totalPnl = totalPnl.add(order.getRealisedPnl());
+                realisedPnl = realisedPnl.add(order.getRealisedPnl());
 
                 if (order.getRealisedPnl().compareTo(BigDecimal.ZERO) > 0) {
                     winCount++;
@@ -146,6 +146,17 @@ public class TradeOrderController {
                 }
             }
         }
+
+        // Unrealised PnL: enrich open orders with live LTP, then sum.
+        enrichWithLivePnl(openOrders);
+        BigDecimal unrealisedPnl = BigDecimal.ZERO;
+        for (TradeOrder order : openOrders) {
+            if (order.getUnrealisedPnl() != null) {
+                unrealisedPnl = unrealisedPnl.add(order.getUnrealisedPnl());
+            }
+        }
+
+        BigDecimal totalPnl = realisedPnl.add(unrealisedPnl);
 
         BigDecimal avgWin = winCount > 0
                 ? totalWins.divide(BigDecimal.valueOf(winCount), 2, RoundingMode.HALF_UP)
@@ -165,6 +176,8 @@ public class TradeOrderController {
                 .openTrades(openTrades)
                 .winCount(winCount)
                 .lossCount(lossCount)
+                .realisedPnlInr(realisedPnl)
+                .unrealisedPnlInr(unrealisedPnl)
                 .totalPnlInr(totalPnl)
                 .avgWinInr(avgWin)
                 .avgLossInr(avgLoss)

--- a/src/main/java/com/dtech/kitecon/trade/dto/TradeSummaryDto.java
+++ b/src/main/java/com/dtech/kitecon/trade/dto/TradeSummaryDto.java
@@ -15,6 +15,11 @@ public class TradeSummaryDto {
     private int openTrades;
     private int winCount;
     private int lossCount;
+    /** Realised PnL: sum across CLOSED orders. */
+    private BigDecimal realisedPnlInr;
+    /** Unrealised PnL: sum across OPEN orders using last LTP mark (null if no LTP). */
+    private BigDecimal unrealisedPnlInr;
+    /** realisedPnlInr + unrealisedPnlInr (treats null unrealised as zero). */
     private BigDecimal totalPnlInr;
     private BigDecimal avgWinInr;
     private BigDecimal avgLossInr;

--- a/ui/chart-draw-app/src/tradeMonitor/api.ts
+++ b/ui/chart-draw-app/src/tradeMonitor/api.ts
@@ -53,6 +53,8 @@ export interface TradeSummaryDto {
   openTrades: number;
   winCount: number;
   lossCount: number;
+  realisedPnlInr: number;
+  unrealisedPnlInr: number;
   totalPnlInr: number;
   avgWinInr: number;
   avgLossInr: number;

--- a/ui/chart-draw-app/src/tradeMonitor/pages/TradeOrdersPage.tsx
+++ b/ui/chart-draw-app/src/tradeMonitor/pages/TradeOrdersPage.tsx
@@ -220,7 +220,9 @@ const TradeOrdersPage: React.FC = () => {
     );
   }
 
-  const pnlValue = summary?.totalPnlInr || 0;
+  const realisedPnl = summary?.realisedPnlInr || 0;
+  const unrealisedPnl = summary?.unrealisedPnlInr || 0;
+  const totalPnl = summary?.totalPnlInr || 0;
   const winRate = summary?.winRatePct || 0;
 
   return (
@@ -258,10 +260,24 @@ const TradeOrdersPage: React.FC = () => {
       {summary && (
         <div style={summaryBarStyle}>
           <div style={summaryItemStyle}>
+            <div style={summaryLabelStyle}>Realised P&L</div>
+            <div style={summaryValueStyle(realisedPnl)}>
+              {realisedPnl > 0 ? "+" : ""}
+              {realisedPnl.toFixed(2)}
+            </div>
+          </div>
+          <div style={summaryItemStyle}>
+            <div style={summaryLabelStyle}>Unrealised P&L</div>
+            <div style={summaryValueStyle(unrealisedPnl)}>
+              {unrealisedPnl > 0 ? "+" : ""}
+              {unrealisedPnl.toFixed(2)}
+            </div>
+          </div>
+          <div style={summaryItemStyle}>
             <div style={summaryLabelStyle}>Total P&L</div>
-            <div style={summaryValueStyle(pnlValue)}>
-              {pnlValue > 0 ? "+" : ""}
-              {pnlValue.toFixed(2)}
+            <div style={summaryValueStyle(totalPnl)}>
+              {totalPnl > 0 ? "+" : ""}
+              {totalPnl.toFixed(2)}
             </div>
           </div>
           <div style={summaryItemStyle}>


### PR DESCRIPTION
## Summary
- Backend `TradeSummaryDto` exposes `realisedPnlInr`, `unrealisedPnlInr`, `totalPnlInr`
- `TradeOrderController.getSummary()` marks open orders to live LTP and sums realised + unrealised separately
- Trade Orders page summary bar replaces single Total P&L with three stats: Realised, Unrealised, Total

Closes #153

## Test plan
- [ ] Hit `GET /api/trade-orders/summary` and confirm response contains all three PnL fields
- [ ] Open Trade Orders page and verify three stats render with correct color coding (green positive, red negative)
- [ ] With at least one OPEN trade, verify Unrealised value is non-zero and tracks live LTP
- [ ] With no OPEN trades, verify Unrealised shows ₹0.00 and Total equals Realised

🤖 Generated with [Claude Code](https://claude.com/claude-code)