### PR TITLE
fix: TradeSignal.paperTrade NOT NULL DEFAULT to prevent ddl-auto crash

### DIFF
--- a/src/main/java/com/dtech/kitecon/trade/entity/TradeSignal.java
+++ b/src/main/java/com/dtech/kitecon/trade/entity/TradeSignal.java
@@ -119,7 +119,8 @@ public class TradeSignal {
     @Column
     private Integer barsSinceLastSlabAdvance;
 
-    @Column
+    @Column(nullable = false)
+    @org.hibernate.annotations.ColumnDefault("0")
     private boolean paperTrade;
 
     @PrePersist


### PR DESCRIPTION
## Summary
- Adds `nullable = false` + `@ColumnDefault("0")` to `TradeSignal.paperTrade`
- Prevents recurrence of the prod issue from PR #156 deploy where Hibernate ddl-auto=update created the column nullable and existing rows had NULL, breaking primitive boolean reads
- Prod DB already patched live; this brings the entity into alignment

Closes #157

## Test plan
- [ ] Backend boots without TradeSignal load errors
- [ ] No regression on signal creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)