### PR TITLE
fix: skip illiquid-quote entries (entryPrice <= 0) + disable lenient trendline

### DIFF
--- a/src/main/java/com/dtech/kitecon/trade/service/PaperOrderExecutionService.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/PaperOrderExecutionService.java
@@ -55,6 +55,15 @@ public class PaperOrderExecutionService {
                 ? instrumentQuote.getAskPrice()
                 : instrumentQuote.getBidPrice();
 
+        // Guard against illiquid quotes with zero/null prices
+        if (entryPrice == null || entryPrice.compareTo(BigDecimal.ZERO) <= 0) {
+            log.warn("[PaperOrder] SKIP signal={} {} — illiquid quote bid={} ask={} resolved={}",
+                    signal.getId(), signal.getSymbol(),
+                    instrumentQuote.getBidPrice(), instrumentQuote.getAskPrice(),
+                    resolved.getTradingSymbol());
+            return null;
+        }
+
         int qty = capitalAllocationService.computeQuantity(
                 config.getCapitalPct(), entryPrice, resolved.getLotSize());
 

--- a/src/main/java/com/dtech/kitecon/trade/service/TradeOrchestrationService.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/TradeOrchestrationService.java
@@ -66,11 +66,13 @@ public class TradeOrchestrationService {
                     continue;
                 }
 
-                paperOrderExecutionService.enter(signal, config, resolved, instrumentQuote, underlyingQuote);
-                try {
-                    tradeActionLogger.log(signal, TradeActionLog.TradeAction.ENTRY_FILLED, ltp, "Order placed");
-                } catch (Exception e) {
-                    log.warn("Failed to log trade action: {}", e.getMessage());
+                TradeOrder order = paperOrderExecutionService.enter(signal, config, resolved, instrumentQuote, underlyingQuote);
+                if (order != null) {
+                    try {
+                        tradeActionLogger.log(signal, TradeActionLog.TradeAction.ENTRY_FILLED, ltp, "Order placed");
+                    } catch (Exception e) {
+                        log.warn("Failed to log trade action: {}", e.getMessage());
+                    }
                 }
 
             } catch (Exception e) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -169,6 +169,6 @@ impulse.otm.distance.pct=3
 impulse.simulation.segment=EQ
 impulse.live.orders=true
 
-trendline.lenient.enabled=true
+trendline.lenient.enabled=false
 trendline.lenient.paper.trade=true
 


### PR DESCRIPTION
## Summary
- **Guard:** \`PaperOrderExecutionService.enter()\` returns null + logs WARN when computed entryPrice is null or <= 0; \`TradeOrchestrationService\` skips ENTRY_FILLED log when entry was rejected
- **Disable lenient:** \`trendline.lenient.enabled=false\` until we add confidence scoring + per-symbol dedup

## Background
Lenient trendline (PR #156) flooded prod with 1541 signals → 210 paper orders, all on OPT segment, ₹-1.78L realised PnL — many on illiquid contracts where the quote returned 0 bid/ask and the order ended up with entryPrice = 0. Those rows have already been purged from prod DB. The lenient feature stays gated off until we ship confidence + dedup.

Closes #159

## Test plan
- [ ] Confirm a synthetic illiquid quote (bid=0/ask=0) results in WARN log + no TradeOrder row
- [ ] Confirm normal liquid quotes still create orders
- [ ] After deploy, no new lenient signals appear in DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)