### PR TITLE
chore: gate DTB+HNS signal creation behind properties; disable in prod

### DIFF
--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
@@ -48,6 +48,12 @@ public class PatternComboScannerService {
     @Value("${trendline.lenient.paper.trade:true}")
     private boolean lenientPaperTrade;
 
+    @Value("${pattern.dtb.enabled:true}")
+    private boolean dtbEnabled;
+
+    @Value("${pattern.hns.enabled:true}")
+    private boolean hnsEnabled;
+
     private final AtomicBoolean scanRunning = new AtomicBoolean(false);
 
     @Scheduled(cron = "0 0/15 9-15 * * MON-FRI", zone = "Asia/Kolkata")
@@ -135,6 +141,15 @@ public class PatternComboScannerService {
     }
 
     SignalCreationResult createSignalForPattern(String symbol, PatternDto pattern, String timeframe, boolean paperTrade) {
+        // Gate disabled pattern families — skip signal creation without removing detection code.
+        String pt = pattern.getPatternType();
+        if (!dtbEnabled && ("DOUBLE_BOTTOM".equals(pt) || "DOUBLE_TOP".equals(pt))) {
+            return SignalCreationResult.duplicate();
+        }
+        if (!hnsEnabled && ("HNS_BULL".equals(pt) || "HNS_BEAR".equals(pt))) {
+            return SignalCreationResult.duplicate();
+        }
+
         List<TradeSignal> openSignals = tradeSignalRepository.findBySymbolAndStatusIn(
                 symbol, List.of(TradeStatus.WATCHING_ENTRY, TradeStatus.ENTRY_PENDING, TradeStatus.ACTIVE));
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -172,3 +172,5 @@ impulse.live.orders=true
 trendline.lenient.enabled=false
 trendline.lenient.paper.trade=true
 
+pattern.dtb.enabled=false
+pattern.hns.enabled=false


### PR DESCRIPTION
## Summary
- New \`pattern.dtb.enabled\` and \`pattern.hns.enabled\` properties (default true; \`application.properties\` sets both false)
- \`PatternComboScannerService.createSignalForPattern\` early-returns \`duplicate()\` for DOUBLE_BOTTOM/DOUBLE_TOP/HNS_BULL/HNS_BEAR when their flag is false
- Detection code in \`PatternComboBacktestService\` is untouched — sim still sees patterns

Background: see #168 for the 4-phase redesign plan.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)