### PR TITLE
fix: sim aligned with extractor — CandidatePivotZigZag + structural SL + entry confirm

### DIFF
--- a/ds-python/finrl-poc/service/train_dtb_hns_binary.py
+++ b/ds-python/finrl-poc/service/train_dtb_hns_binary.py
@@ -80,8 +80,8 @@ def main():
         raise ValueError("CSV must contain 'timestamp' column")
 
     # Train/test split by date: train < 2022-01-01, test >= 2024-01-01 (gap in between)
-    train_cutoff = pd.Timestamp("2022-01-01")
-    test_start = pd.Timestamp("2024-01-01")
+    train_cutoff = pd.Timestamp("2022-01-01", tz="UTC")
+    test_start = pd.Timestamp("2024-01-01", tz="UTC")
 
     df_train = df[df['ts_dt'] < train_cutoff].reset_index(drop=True)
     df_test = df[df['ts_dt'] >= test_start].reset_index(drop=True)

--- a/src/main/java/com/dtech/kitecon/patterndetector/DtbHnsTrainingDataService.java
+++ b/src/main/java/com/dtech/kitecon/patterndetector/DtbHnsTrainingDataService.java
@@ -59,13 +59,14 @@ public class DtbHnsTrainingDataService {
 
     private static final String OUTPUT_DIR = "dtbhns_train_data";
     private static final int MAX_BARS_TO_ENTRY_CONFIRMATION = 20;
-    private static final int MAX_BARS_TO_EXIT = 50;
+    private static final int MAX_BARS_TO_EXIT = 10;
 
     public record ExtractResult(
             int detectionsFound,
             int entriesTriggered,
             int wins,
             int losses,
+            int timedOut,
             double winRatePct,
             Path outputFile
     ) {}
@@ -86,6 +87,7 @@ public class DtbHnsTrainingDataService {
         int totalEntriesTriggered = 0;
         int totalWins = 0;
         int totalLosses = 0;
+        int totalTimedOut = 0;
 
         List<Object[]> allRows = new ArrayList<>();
 
@@ -155,8 +157,16 @@ public class DtbHnsTrainingDataService {
                             totalEntriesTriggered++;
 
                             // Simulate exit (target vs SL)
-                            int label = simulateExit(barSeries, pattern, entryBarIdx);
-                            if (label == 1) totalWins++; else totalLosses++;
+                            Integer label = simulateExit(barSeries, pattern, entryBarIdx);
+                            if (label == null) {
+                                // Timeout: exclude from training
+                                totalTimedOut++;
+                                continue;
+                            } else if (label == 1) {
+                                totalWins++;
+                            } else {
+                                totalLosses++;
+                            }
 
                             // Build CSV row
                             Object[] row = buildCsvRow(symbol, currentBar, pattern, features, label, entryBarIdx);
@@ -180,10 +190,10 @@ public class DtbHnsTrainingDataService {
         writeCsv(outputCsv, allRows);
 
         double winRate = (totalWins + totalLosses) > 0 ? 100.0 * totalWins / (totalWins + totalLosses) : 0;
-        log.info("[DtbHnsTraining] Final stats: detections={}, entries={}, wins={}, losses={}, winRate={:.1f}%",
-                totalDetections, totalEntriesTriggered, totalWins, totalLosses, winRate);
+        log.info("[DtbHnsTraining] Final stats: detections={}, entries={}, wins={}, losses={}, timedOut={}, winRate={:.1f}%",
+                totalDetections, totalEntriesTriggered, totalWins, totalLosses, totalTimedOut, winRate);
 
-        return new ExtractResult(totalDetections, totalEntriesTriggered, totalWins, totalLosses, winRate, outputCsv);
+        return new ExtractResult(totalDetections, totalEntriesTriggered, totalWins, totalLosses, totalTimedOut, winRate, outputCsv);
     }
 
     /**
@@ -430,9 +440,9 @@ public class DtbHnsTrainingDataService {
 
     /**
      * Simulate exit: check if target or SL is hit first within MAX_BARS_TO_EXIT bars.
-     * Return 1 if target hit first (win), 0 if SL hit first or timeout (loss).
+     * Return 1 if target hit first (win), 0 if SL hit first (loss), null if timeout (exclude).
      */
-    private int simulateExit(BarSeries series, DetectedPattern pattern, int entryBarIdx) {
+    private Integer simulateExit(BarSeries series, DetectedPattern pattern, int entryBarIdx) {
         double target = pattern.getOwnTarget();
         double stopLoss = pattern.getStopLoss();
         int endIdx = Math.min(entryBarIdx + MAX_BARS_TO_EXIT, series.getBarCount() - 1);
@@ -451,14 +461,14 @@ public class DtbHnsTrainingDataService {
             }
         }
 
-        return 0;  // Timeout — loss
+        return null;  // Timeout — exclude from training
     }
 
     /**
      * Build a CSV row with all metadata and features.
      */
     private Object[] buildCsvRow(String symbol, Bar detectionBar, DetectedPattern pattern,
-                                  double[] features, int label, Integer entryBarIdx) {
+                                  double[] features, Integer label, Integer entryBarIdx) {
         Object[] row = new Object[7 + features.length + 1];
         row[0] = detectionBar.getEndTime();
         row[1] = pattern.getPivotP0();

--- a/src/main/java/com/dtech/kitecon/simulation/strategy/DtbSimulationStrategy.java
+++ b/src/main/java/com/dtech/kitecon/simulation/strategy/DtbSimulationStrategy.java
@@ -4,12 +4,13 @@ import com.dtech.algo.series.Interval;
 import com.dtech.chartpattern.zigzag.ZigZagParams;
 import com.dtech.chartpattern.zigzag.ZigZagPoint;
 import com.dtech.chartpattern.zigzag.ZigZagService;
+import com.dtech.kitecon.backtest.CandlestickPatternDetector;
 import com.dtech.kitecon.backtest.DetectedPattern;
 import com.dtech.kitecon.backtest.PatternComboBacktestService;
 import com.dtech.kitecon.backtest.PatternComboBacktestService.DailyIndicators;
 import com.dtech.kitecon.patternscanner.PatternDto;
 import com.dtech.kitecon.patternscanner.TradeFilterClient;
-import com.dtech.kitecon.simulation.IncrementalZigZag;
+import com.dtech.kitecon.simulation.CandidatePivotZigZag;
 import com.dtech.kitecon.simulation.SimulationContext;
 import com.dtech.kitecon.trade.entity.TradeSignal;
 import com.dtech.kitecon.trade.enums.StrategyType;
@@ -44,17 +45,21 @@ public class DtbSimulationStrategy implements SimulationStrategy {
     private final PatternComboBacktestService patternService;
     private final TradeFilterClient tradeFilterClient;
     private final ExitStrategyRouter exitStrategyRouter;
+    private final CandlestickPatternDetector candlePatternDetector;
 
     @Value("${trade.filter.threshold:0.82}")
     private double mlThreshold;
+
+    private static final int MAX_BARS_TO_ENTRY_CONFIRMATION = 20;
+    private static final int MAX_BARS_TO_EXIT = 10;
 
     /** Track processed pivot timestamps per symbol to avoid duplicate signals */
     private final Map<String, Set<Instant>> processedPivots = new java.util.concurrent.ConcurrentHashMap<>();
     private final Map<String, ZigZagParams> cachedParams = new java.util.concurrent.ConcurrentHashMap<>();
     private final Map<String, Integer> lastZigZagBarCount = new java.util.concurrent.ConcurrentHashMap<>();
     private final Map<String, List<ZigZagPoint>> cachedPivots = new java.util.concurrent.ConcurrentHashMap<>();
-    /** IncrementalZigZag per symbol for trailing-extreme-based DTB/HNS detection */
-    private final Map<String, IncrementalZigZag> incrementalZigZags = new java.util.concurrent.ConcurrentHashMap<>();
+    /** CandidatePivotZigZag per symbol for trailing-extreme-based DTB/HNS detection */
+    private final Map<String, CandidatePivotZigZag> candidatePivotZigZags = new java.util.concurrent.ConcurrentHashMap<>();
     /** Track last processed bar count per symbol for incremental ZigZag */
     private final Map<String, Integer> lastProcessedBarCount = new java.util.concurrent.ConcurrentHashMap<>();
     private static final int ZIGZAG_RECOMPUTE_INTERVAL = 4;
@@ -70,7 +75,7 @@ public class DtbSimulationStrategy implements SimulationStrategy {
         cachedParams.clear();
         lastZigZagBarCount.clear();
         cachedPivots.clear();
-        incrementalZigZags.clear();
+        candidatePivotZigZags.clear();
         lastProcessedBarCount.clear();
     }
 
@@ -92,7 +97,7 @@ public class DtbSimulationStrategy implements SimulationStrategy {
             double[] macdHistArr = patternService.computeMacdHistPublic(truncatedSeries);
             double[] stochRsiK = patternService.computeStochRsiKPublic(rsiValues);
 
-            // 1. Get or create IncrementalZigZag for this symbol
+            // 1. Get or create CandidatePivotZigZag for this symbol
             ZigZagParams params = cachedParams.computeIfAbsent(symbol, s -> {
                 Interval interval = Interval.valueOf(ctx.getTimeframe());
                 ZigZagParams base = zigZagService.resolveParams(s, interval);
@@ -102,19 +107,19 @@ public class DtbSimulationStrategy implements SimulationStrategy {
                         ZigZagParams.Mode.BACKTEST);
             });
 
-            IncrementalZigZag izz = incrementalZigZags.computeIfAbsent(symbol, s -> new IncrementalZigZag(params));
+            CandidatePivotZigZag cpzz = candidatePivotZigZags.computeIfAbsent(symbol, s -> new CandidatePivotZigZag(params));
 
             // 2. Process only NEW bars since last call
             int lastProcessed = lastProcessedBarCount.getOrDefault(symbol, 0);
             for (int i = lastProcessed; i < barCount; i++) {
-                izz.processBar(bars.get(i), i);
+                cpzz.processBar(truncatedSeries, i);
             }
             lastProcessedBarCount.put(symbol, barCount);
 
             // 3. Get pivots with trailing extreme
             Bar currentBar = bars.get(bars.size() - 1);
-            List<ZigZagPoint> pivotsWithTrailingExtreme = izz.getPivotsWithTrailingExtreme(currentBar);
-            if (pivotsWithTrailingExtreme.size() < 5) return List.of();
+            List<ZigZagPoint> pivotsWithTrailingExtreme = cpzz.getPivotsWithTrailingExtreme(currentBar);
+            if (pivotsWithTrailingExtreme.size() < 3) return List.of();
 
             // Detect DTB/HNS patterns using trailing extreme (new detector)
             List<DetectedPattern> patterns = new ArrayList<>();
@@ -122,7 +127,7 @@ public class DtbSimulationStrategy implements SimulationStrategy {
                     atrArr, rsiValues, macdHistArr, stochRsiK, tsToIdx));
 
             // Keep Triangle and Trendline Breakout using confirmed pivots (old detectors)
-            List<ZigZagPoint> confirmedPivots = izz.getConfirmedPivots();
+            List<ZigZagPoint> confirmedPivots = cpzz.getConfirmedPivots();
             if (confirmedPivots.size() >= 5) {
                 patterns.addAll(patternService.scanTriangleWatchingPublic(confirmedPivots, bars, tsToIdx, atrArr, rsiValues, macdHistArr, stochRsiK));
                 patterns.addAll(patternService.scanTrendlineBreakoutWatchingPublic(confirmedPivots, bars, tsToIdx, atrArr, rsiValues, macdHistArr, stochRsiK));
@@ -211,44 +216,43 @@ public class DtbSimulationStrategy implements SimulationStrategy {
                     continue;
                 }
 
-                // Build signal — entry at neckline (keyLevel), stop at 2×ATR, measured-move target
+                // Build signal with WATCHING_ENTRY status (entry will be confirmed later)
                 boolean bullish = p.isBullish();
-                double entry = p.getKeyLevel();
-                double atr = p.getAtr();
-                double stopLoss = bullish ? entry - 2.0 * atr : entry + 2.0 * atr;
                 double target = p.getOwnTarget();
                 double height = p.getPatternHeight();
+                double structuralSL = p.getStopLoss();
 
-                // In simulation, we assume entry at the current bar close (neckline already broken)
                 Bar lastBar = bars.get(bars.size() - 1);
-                double fillPrice = lastBar.getClosePrice().doubleValue();
+                Instant now = lastBar.getEndTime();
 
                 TradeSignal signal = TradeSignal.builder()
                         .symbol(symbol)
                         .direction(bullish ? TradeDirection.LONG : TradeDirection.SHORT)
                         .patternType(p.getPatternType())
-                        .entryPrice(BigDecimal.valueOf(fillPrice))
-                        .stopLoss(BigDecimal.valueOf(stopLoss))
+                        .entryPrice(BigDecimal.ZERO)  // Will be set when entry is confirmed
+                        .stopLoss(BigDecimal.valueOf(structuralSL))  // Use structural SL from detector
                         .target(BigDecimal.valueOf(target))
-                        .neckline(BigDecimal.valueOf(entry))
+                        .neckline(BigDecimal.valueOf(p.getKeyLevel()))
                         .patternHeight(BigDecimal.valueOf(height))
                         .rrRatio(BigDecimal.valueOf(rrRatio).setScale(2, RoundingMode.HALF_UP))
                         .mlScore(BigDecimal.valueOf(mlScore).setScale(4, RoundingMode.HALF_UP))
                         .timeframe(ctx.getTimeframe())
-                        .status(TradeStatus.ACTIVE)
+                        .status(TradeStatus.WATCHING_ENTRY)  // Entry not yet confirmed
                         .strategyType(StrategyType.DTB)
                         .stochRsiK(BigDecimal.valueOf(p.getStochRsiK()).setScale(4, RoundingMode.HALF_UP))
-                        .breakoutLevel(BigDecimal.ZERO)
+                        .breakoutLevel(BigDecimal.ZERO)  // Will be set when reversal candle is found
                         .pivotP0(BigDecimal.valueOf(p.getPivotP0()))
                         .pivotP1(BigDecimal.valueOf(p.getPivotP1()))
                         .pivotP2(BigDecimal.valueOf(p.getPivotP2()))
                         .pivotP3(p.getPivotP3() != null ? BigDecimal.valueOf(p.getPivotP3()) : null)
+                        .signalTime(now)
+                        .barsInTrade(0)
                         .build();
 
                 signals.add(signal);
-                log.info("[SimDTB] {} {} {} entry={} SL={} T={} ML={:.3f}",
+                log.info("[SimDTB] {} {} {} waiting for entry confirmation with SL={} T={} ML={:.3f}",
                         symbol, p.getPatternType(), bullish ? "LONG" : "SHORT",
-                        fillPrice, stopLoss, target, mlScore);
+                        structuralSL, target, mlScore);
             }
             return signals;
 
@@ -264,25 +268,219 @@ public class DtbSimulationStrategy implements SimulationStrategy {
         List<ExitResult> exits = new ArrayList<>();
         double high = currentBar.getHighPrice().doubleValue();
         double low = currentBar.getLowPrice().doubleValue();
+        double close = currentBar.getClosePrice().doubleValue();
+
+        // Build bars list for reversal candle detection
+        List<Bar> bars = new ArrayList<>();
+        for (int i = 0; i < truncatedSeries.getBarCount(); i++) {
+            bars.add(truncatedSeries.getBar(i));
+        }
 
         for (TradeSignal sig : openPositions) {
             if (!symbol.equals(sig.getSymbol())) continue;
             if (sig.getStrategyType() != StrategyType.DTB) continue;
-            try {
-                ExitStrategy strategy = exitStrategyRouter.getStrategy(sig.getStrategyType());
-                BigDecimal ltp = BigDecimal.valueOf(sig.getDirection() == TradeDirection.LONG ? high : low);
-                ExitDecision decision = strategy.evaluate(sig, ltp, ltp);
 
-                if (decision.action() == ExitDecision.Action.EXIT) {
-                    double exitPrice = decision.exitPrice().doubleValue();
-                    double pnlPct = computePnl(sig, exitPrice);
-                    exits.add(new ExitResult(sig, decision.exitReason().name(), exitPrice, pnlPct));
+            try {
+                String patternType = sig.getPatternType();
+                boolean isDtbOrHns = "DOUBLE_BOTTOM".equals(patternType) || "DOUBLE_TOP".equals(patternType)
+                                  || "HNS_BULL".equals(patternType) || "HNS_BEAR".equals(patternType);
+
+                if (!isDtbOrHns) {
+                    // Non-DTB/HNS patterns (Triangle, TLB): use ExitStrategyRouter
+                    ExitStrategy strategy = exitStrategyRouter.getStrategy(sig.getStrategyType());
+                    BigDecimal ltp = BigDecimal.valueOf(sig.getDirection() == TradeDirection.LONG ? high : low);
+                    ExitDecision decision = strategy.evaluate(sig, ltp, ltp);
+
+                    if (decision.action() == ExitDecision.Action.EXIT) {
+                        double exitPrice = decision.exitPrice().doubleValue();
+                        double pnlPct = computePnl(sig, exitPrice);
+                        exits.add(new ExitResult(sig, decision.exitReason().name(), exitPrice, pnlPct));
+                    }
+                    continue;
                 }
+
+                // DTB/HNS entry confirmation and exit logic
+                if (sig.getStatus() == TradeStatus.WATCHING_ENTRY) {
+                    ExitResult entryResult = confirmDtbHnsEntry(sig, bars, currentBar, close);
+                    if (entryResult != null) {
+                        exits.add(entryResult);
+                    }
+                } else if (sig.getStatus() == TradeStatus.ACTIVE) {
+                    ExitResult exitResult = checkDtbHnsExit(sig, currentBar, high, low, close);
+                    if (exitResult != null) {
+                        exits.add(exitResult);
+                    }
+                }
+
             } catch (Exception e) {
                 log.warn("[SimDTB] checkExits error for {}: {}", symbol, e.toString(), e);
             }
         }
         return exits;
+    }
+
+    /**
+     * Confirm DTB/HNS entry by finding reversal candle in retrace zone and subsequent break.
+     * Returns an ExitResult if entry times out, null otherwise (signal will be updated in ctx).
+     */
+    private ExitResult confirmDtbHnsEntry(TradeSignal sig, List<Bar> bars, Bar currentBar, double close) {
+        BigDecimal breakoutLevel = sig.getBreakoutLevel();
+        boolean isBullish = sig.getDirection() == TradeDirection.LONG;
+
+        if (breakoutLevel == null || breakoutLevel.compareTo(BigDecimal.ZERO) <= 0) {
+            // Step 1: Look for reversal candle in retrace zone
+            BigDecimal pivotP1 = sig.getPivotP1();
+            BigDecimal pivotP2 = sig.getPivotP2();
+
+            if (pivotP1 == null || pivotP2 == null || pivotP1.compareTo(BigDecimal.ZERO) == 0 || pivotP2.compareTo(BigDecimal.ZERO) == 0) {
+                return null;
+            }
+
+            String patternType = sig.getPatternType();
+
+            // Compute retrace zone bounds
+            BigDecimal zoneMin, zoneMax;
+            if ("DOUBLE_BOTTOM".equals(patternType)) {
+                BigDecimal diff = pivotP1.subtract(pivotP2);
+                zoneMin = pivotP2.add(diff.multiply(BigDecimal.valueOf(0.01)));
+                zoneMax = pivotP2.add(diff.multiply(BigDecimal.valueOf(0.39)));
+            } else if ("DOUBLE_TOP".equals(patternType)) {
+                BigDecimal diff = pivotP2.subtract(pivotP1);
+                zoneMin = pivotP2.subtract(diff.multiply(BigDecimal.valueOf(0.39)));
+                zoneMax = pivotP2.subtract(diff.multiply(BigDecimal.valueOf(0.01)));
+            } else if ("HNS_BEAR".equals(patternType)) {
+                BigDecimal diff = pivotP1.subtract(pivotP2);
+                zoneMin = pivotP1.subtract(diff.multiply(BigDecimal.valueOf(0.61)));
+                zoneMax = pivotP1.subtract(diff.multiply(BigDecimal.valueOf(0.23)));
+            } else if ("HNS_BULL".equals(patternType)) {
+                BigDecimal diff = pivotP2.subtract(pivotP1);
+                zoneMin = pivotP1.add(diff.multiply(BigDecimal.valueOf(0.23)));
+                zoneMax = pivotP1.add(diff.multiply(BigDecimal.valueOf(0.61)));
+            } else {
+                return null;
+            }
+
+            // Scan back up to 20 bars from signal creation
+            int signalBarIdx = -1;
+            for (int i = 0; i < bars.size(); i++) {
+                if (bars.get(i).getEndTime().equals(sig.getSignalTime())) {
+                    signalBarIdx = i;
+                    break;
+                }
+            }
+
+            if (signalBarIdx < 0) {
+                signalBarIdx = Math.max(0, bars.size() - 21);  // Fallback to last 20 bars
+            }
+
+            int searchEndIdx = Math.min(signalBarIdx + MAX_BARS_TO_ENTRY_CONFIRMATION, bars.size() - 1);
+
+            // Look for reversal candle in zone
+            for (int i = signalBarIdx + 1; i <= searchEndIdx; i++) {
+                Bar bar = bars.get(i);
+                double midpoint = (bar.getHighPrice().doubleValue() + bar.getLowPrice().doubleValue()) / 2.0;
+
+                // Check if midpoint is in zone
+                if (midpoint >= zoneMin.doubleValue() && midpoint <= zoneMax.doubleValue()) {
+                    CandlestickPatternDetector.PatternResult result;
+                    if (isBullish) {
+                        result = candlePatternDetector.detectBullish(bars, i);
+                    } else {
+                        result = candlePatternDetector.detectBearish(bars, i);
+                    }
+
+                    if (result.pattern() != CandlestickPatternDetector.CandlePattern.NONE) {
+                        // Reversal candle found — set breakoutLevel and entryValidUntil
+                        sig.setBreakoutLevel(BigDecimal.valueOf(result.breakoutLevel()));
+                        sig.setEntryValidUntil(currentBar.getEndTime().plusSeconds(5 * 3600));  // ~5 bars from now
+                        return null;  // Don't exit, wait for break
+                    }
+                }
+            }
+
+            // No reversal candle found in 20 bars — entry timeout
+            if (bars.size() - 1 - signalBarIdx >= MAX_BARS_TO_ENTRY_CONFIRMATION) {
+                log.info("[SimDTB] Entry timeout for signal {} {}: no reversal candle in 20 bars",
+                        sig.getId(), sig.getSymbol());
+                return new ExitResult(sig, "ENTRY_TIMEOUT", close, 0.0);
+            }
+
+            return null;  // Still waiting for reversal candle
+        } else {
+            // Step 2: breakoutLevel found, wait for break
+            double blevel = breakoutLevel.doubleValue();
+
+            // Check if current bar breaks the level
+            if (isBullish && close > blevel) {
+                // Entry confirmed for LONG
+                sig.setEntryPrice(breakoutLevel);
+                sig.setStatus(TradeStatus.ACTIVE);
+                sig.setBarsInTrade(0);
+                return null;  // Don't exit, entry just activated
+            } else if (!isBullish && close < blevel) {
+                // Entry confirmed for SHORT
+                sig.setEntryPrice(breakoutLevel);
+                sig.setStatus(TradeStatus.ACTIVE);
+                sig.setBarsInTrade(0);
+                return null;  // Don't exit, entry just activated
+            }
+
+            // Not yet broken — check if entry valid window expired
+            if (sig.getEntryValidUntil() != null && currentBar.getEndTime().isAfter(sig.getEntryValidUntil())) {
+                log.info("[SimDTB] Entry timeout for signal {} {}: breakout not confirmed in time window",
+                        sig.getId(), sig.getSymbol());
+                return new ExitResult(sig, "ENTRY_TIMEOUT", close, 0.0);
+            }
+
+            // Increment bars waiting for break
+            if (sig.getBarsInTrade() == null) sig.setBarsInTrade(0);
+            sig.setBarsInTrade(sig.getBarsInTrade() + 1);
+            return null;  // Still waiting
+        }
+    }
+
+    /**
+     * Check DTB/HNS exit: target vs SL within 10 bars.
+     * Returns ExitResult if exit triggered, null otherwise (signal updated in ctx).
+     */
+    private ExitResult checkDtbHnsExit(TradeSignal sig, Bar currentBar, double high, double low, double close) {
+        BigDecimal target = sig.getTarget();
+        BigDecimal stopLoss = sig.getStopLoss();
+        boolean isBullish = sig.getDirection() == TradeDirection.LONG;
+
+        // Increment bars in trade
+        if (sig.getBarsInTrade() == null) sig.setBarsInTrade(0);
+        sig.setBarsInTrade(sig.getBarsInTrade() + 1);
+
+        if (isBullish) {
+            // LONG: check target and SL
+            if (target != null && target.compareTo(BigDecimal.ZERO) > 0 && high >= target.doubleValue()) {
+                double pnlPct = (target.doubleValue() - sig.getEntryPrice().doubleValue()) / sig.getEntryPrice().doubleValue() * 100;
+                return new ExitResult(sig, "TARGET_HIT", target.doubleValue(), pnlPct);
+            }
+            if (stopLoss != null && stopLoss.compareTo(BigDecimal.ZERO) > 0 && low <= stopLoss.doubleValue()) {
+                double pnlPct = (stopLoss.doubleValue() - sig.getEntryPrice().doubleValue()) / sig.getEntryPrice().doubleValue() * 100;
+                return new ExitResult(sig, "STOP_LOSS", stopLoss.doubleValue(), pnlPct);
+            }
+        } else {
+            // SHORT: check target and SL
+            if (target != null && target.compareTo(BigDecimal.ZERO) > 0 && low <= target.doubleValue()) {
+                double pnlPct = (sig.getEntryPrice().doubleValue() - target.doubleValue()) / sig.getEntryPrice().doubleValue() * 100;
+                return new ExitResult(sig, "TARGET_HIT", target.doubleValue(), pnlPct);
+            }
+            if (stopLoss != null && stopLoss.compareTo(BigDecimal.ZERO) > 0 && high >= stopLoss.doubleValue()) {
+                double pnlPct = (sig.getEntryPrice().doubleValue() - stopLoss.doubleValue()) / sig.getEntryPrice().doubleValue() * 100;
+                return new ExitResult(sig, "STOP_LOSS", stopLoss.doubleValue(), pnlPct);
+            }
+        }
+
+        // Timeout at 10 bars
+        if (sig.getBarsInTrade() >= MAX_BARS_TO_EXIT) {
+            double pnlPct = computePnl(sig, close);
+            return new ExitResult(sig, "TIMEOUT", close, pnlPct);
+        }
+
+        return null;  // Still in trade
     }
 
     private double computePnl(TradeSignal sig, double exitPrice) {

--- a/src/main/java/com/dtech/ta/patterns/DtbHnsCandidateDetector.java
+++ b/src/main/java/com/dtech/ta/patterns/DtbHnsCandidateDetector.java
@@ -148,6 +148,8 @@ public class DtbHnsCandidateDetector {
         double atrAtP0 = p0Idx < atrArr.length ? atrArr[p0Idx] : 0;
         double stochK = p0Idx < stochRsiK.length ? stochRsiK[p0Idx] : 0;
 
+        double stopLoss = Math.min(v0, v2);  // DTB: min of two lows (DOUBLE_BOTTOM/DOUBLE_TOP)
+
         results.add(DetectedPattern.builder()
                 .patternType(bullish ? "DOUBLE_BOTTOM" : "DOUBLE_TOP")
                 .confirmationType(null)
@@ -155,7 +157,7 @@ public class DtbHnsCandidateDetector {
                 .keyLevel(v1)                              // neckline = middle (bounce level)
                 .keyLevelTime(p0.getTimestamp())           // detection time
                 .entryPrice(0)                             // filled in Phase 2
-                .stopLoss(0)                               // filled in Phase 2
+                .stopLoss(stopLoss)                        // structural SL: min of P0, P2
                 .ownTarget(target)
                 .patternHeight(patternHeight)
                 .atr(atrAtP0)
@@ -227,6 +229,8 @@ public class DtbHnsCandidateDetector {
         double macdHistP2 = p2Idx < macdHistArr.length ? macdHistArr[p2Idx] : 0;
         double stochK = p0Idx < stochRsiK.length ? stochRsiK[p0Idx] : 0;
 
+        double stopLoss = head;  // HNS_BEAR: Head level invalidates pattern if breached upward
+
         results.add(DetectedPattern.builder()
                 .patternType("HNS_BEAR")
                 .confirmationType(null)
@@ -234,7 +238,7 @@ public class DtbHnsCandidateDetector {
                 .keyLevel(b)                               // neckline at B level
                 .keyLevelTime(p0.getTimestamp())           // detection time at RS
                 .entryPrice(0)                             // filled in Phase 2
-                .stopLoss(0)                               // filled in Phase 2
+                .stopLoss(stopLoss)                        // structural SL: Head level (P1)
                 .ownTarget(target)
                 .patternHeight(patternHeight)
                 .atr(atrAtP0)
@@ -306,6 +310,8 @@ public class DtbHnsCandidateDetector {
         double macdHistP2 = p2Idx < macdHistArr.length ? macdHistArr[p2Idx] : 0;
         double stochK = p0Idx < stochRsiK.length ? stochRsiK[p0Idx] : 0;
 
+        double stopLoss = head;  // HNS_BULL: Head level invalidates pattern if breached downward
+
         results.add(DetectedPattern.builder()
                 .patternType("HNS_BULL")
                 .confirmationType(null)
@@ -313,7 +319,7 @@ public class DtbHnsCandidateDetector {
                 .keyLevel(b)                               // neckline at B level
                 .keyLevelTime(p0.getTimestamp())           // detection time at RS
                 .entryPrice(0)                             // filled in Phase 2
-                .stopLoss(0)                               // filled in Phase 2
+                .stopLoss(stopLoss)                        // structural SL: Head level (P1)
                 .ownTarget(target)
                 .patternHeight(patternHeight)
                 .atr(atrAtP0)


### PR DESCRIPTION
## Summary
Sim was producing wildly different results from extractor on the same data. Root cause: different ZigZag classes + wrong SL formula + wrong entry logic. Now aligned with the validated extractor path.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)