### PR TITLE
chore: enable DTB+HNS gates with ML threshold 0.85

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -172,8 +172,8 @@ impulse.live.orders=true
 trendline.lenient.enabled=false
 trendline.lenient.paper.trade=true
 
-pattern.dtb.enabled=false
-pattern.hns.enabled=false
+pattern.dtb.enabled=true
+pattern.hns.enabled=true
 
 # ── DTB+HNS ML Entry Gate ────
 trade.filter.dtbhns.service.url=http://localhost:5002


### PR DESCRIPTION
Flips pattern.dtb.enabled + pattern.hns.enabled to true. ML scoring service runs on port 5002. Sim path fully wired; live TradeEntryHandler ML gate still TODO (acceptable for paper-trade).