### PR TITLE
fix: re-detect DTB/HNS pattern at ML scoring time for train/serve parity

### DIFF
--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
@@ -216,6 +216,7 @@ public class PatternComboScannerService {
                 .pivotP1(BigDecimal.valueOf(pattern.getPivotP1()))
                 .pivotP2(BigDecimal.valueOf(pattern.getPivotP2()))
                 .pivotP3(pattern.getPivotP3() != null ? BigDecimal.valueOf(pattern.getPivotP3()) : null)
+                .featureSnapshotJson(pattern.getFeatureSnapshotJson())
                 .build();
 
         // ML scoring happens at entry time (TradeEntryHandler) with live indicators — not here.

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternDto.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternDto.java
@@ -56,4 +56,7 @@ public class PatternDto {
     double pivotP2;          // Previous-previous pivot
     Double pivotP3;          // Previous-previous-previous (HNS only, nullable)
     double breakoutLevel;    // Entry confirmation level (populated in Phase 2)
+
+    // Feature snapshot from DetectedPattern at signal creation time (for audit trail)
+    String featureSnapshotJson;  // JSON serialization of DetectedPattern
 }

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternScanService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternScanService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.ta4j.core.Bar;
 import org.ta4j.core.BarSeries;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -32,6 +33,8 @@ public class PatternScanService {
     private final ZigZagService zigZagService;
     private final InstrumentRepository instrumentRepository;
     private final DataFetchService dataFetchService;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     private static final List<String> NIFTY50 = List.of(
         "RELIANCE", "TCS", "HDFCBANK", "BHARTIARTL", "ICICIBANK",
@@ -147,8 +150,10 @@ public class PatternScanService {
         DailyIndicators watchingInd = patternComboBacktestService.computeDailyIndicators(seriesW);
         DailyIndicators confirmInd  = patternComboBacktestService.computeDailyIndicators(seriesC);
 
-        // Build pattern DTOs
-        List<PatternDto> patternDtos = watchingPatterns.stream().map(p -> PatternDto.builder()
+        // Build pattern DTOs with feature snapshots
+        List<PatternDto> patternDtos = watchingPatterns.stream().map(p -> {
+            String featureJson = serializeDetectedPattern(p);
+            return PatternDto.builder()
                 .patternType(p.getPatternType())
                 .bullish(p.isBullish())
                 .keyLevel(p.getKeyLevel())
@@ -188,7 +193,9 @@ public class PatternScanService {
                 .pivotP2(p.getPivotP2())
                 .pivotP3(p.getPivotP3())
                 .breakoutLevel(0.0)
-                .build()).toList();
+                .featureSnapshotJson(featureJson)
+                .build();
+        }).toList();
 
         // Build overlays for watching TF
         Map<String, Object> watchingOverlays = buildOverlays(watchingPatterns, barsW, tsToIdxW);
@@ -241,7 +248,9 @@ public class PatternScanService {
         DailyIndicators dailyInd    = patternComboBacktestService.computeDailyIndicators(seriesDaily);
         DailyIndicators watchingInd = patternComboBacktestService.computeDailyIndicators(seriesW);
 
-        return lenientPatterns.stream().map(p -> PatternDto.builder()
+        return lenientPatterns.stream().map(p -> {
+            String featureJson = serializeDetectedPattern(p);
+            return PatternDto.builder()
                 .patternType(p.getPatternType())
                 .bullish(p.isBullish())
                 .keyLevel(p.getKeyLevel())
@@ -276,7 +285,9 @@ public class PatternScanService {
                 .rsiSlope(watchingInd.rsiSlopeAtTs(p.getKeyLevelTime(), 5))
                 .macdHistSlope(watchingInd.macdHistSlopeAtTs(p.getKeyLevelTime(), 5))
                 .adxSlope(watchingInd.adxSlopeAtTs(p.getKeyLevelTime(), 5))
-                .build()).toList();
+                .featureSnapshotJson(featureJson)
+                .build();
+        }).toList();
     }
 
     /**
@@ -457,5 +468,18 @@ public class PatternScanService {
         pt.put("time", time.getEpochSecond());
         pt.put("price", price);
         return pt;
+    }
+
+    /**
+     * Serialize a DetectedPattern to JSON for audit trail / re-extraction.
+     * Returns null-safe string; if serialization fails, logs warning and returns null.
+     */
+    private String serializeDetectedPattern(DetectedPattern pattern) {
+        try {
+            return objectMapper.writeValueAsString(pattern);
+        } catch (Exception e) {
+            log.warn("Failed to serialize DetectedPattern to JSON: {}", e.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/com/dtech/kitecon/simulation/strategy/DtbSimulationStrategy.java
+++ b/src/main/java/com/dtech/kitecon/simulation/strategy/DtbSimulationStrategy.java
@@ -21,6 +21,8 @@ import com.dtech.kitecon.trade.strategy.ExitDecision;
 import com.dtech.kitecon.trade.strategy.ExitStrategy;
 import com.dtech.kitecon.trade.strategy.ExitStrategyRouter;
 import com.dtech.ta.patterns.DtbHnsFeatureExtractor;
+import com.dtech.ta.patterns.DtbHnsCandidateDetector;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,6 +52,9 @@ public class DtbSimulationStrategy implements SimulationStrategy {
     private final CandlestickPatternDetector candlePatternDetector;
     private final TradeSignalRepository signalRepository;
     private final DtbHnsFeatureExtractor featureExtractor;
+    private final DtbHnsCandidateDetector dtbHnsCandidateDetector;
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
     @Value("${trade.filter.threshold:0.82}")
     private double mlThreshold;
@@ -235,6 +240,9 @@ public class DtbSimulationStrategy implements SimulationStrategy {
                 Bar lastBar = bars.get(bars.size() - 1);
                 Instant now = lastBar.getEndTime();
 
+                // Serialize DetectedPattern to JSON for audit trail
+                String featureSnapshotJson = serializeDetectedPattern(p);
+
                 TradeSignal signal = TradeSignal.builder()
                         .symbol(symbol)
                         .direction(bullish ? TradeDirection.LONG : TradeDirection.SHORT)
@@ -255,6 +263,7 @@ public class DtbSimulationStrategy implements SimulationStrategy {
                         .pivotP1(BigDecimal.valueOf(p.getPivotP1()))
                         .pivotP2(BigDecimal.valueOf(p.getPivotP2()))
                         .pivotP3(p.getPivotP3() != null ? BigDecimal.valueOf(p.getPivotP3()) : null)
+                        .featureSnapshotJson(featureSnapshotJson)
                         .signalTime(now)
                         .barsInTrade(0)
                         .build();
@@ -553,56 +562,49 @@ public class DtbSimulationStrategy implements SimulationStrategy {
 
     /**
      * Apply ML gate for DTB/HNS entry confirmation.
-     * Reconstructs DetectedPattern from signal, extracts features, scores via TradeFilterClient.
+     * Re-detects the pattern to populate all indicator-derived fields for feature extraction.
      * @return ExitResult if ML rejected, null if accepted or service unavailable (fail-open).
      */
     private ExitResult applyDtbHnsMLGate(TradeSignal sig, List<Bar> bars,
                                          double[] atrArr, double[] rsiValues, double[] macdHistArr, double[] stochRsiK,
                                          CandidatePivotZigZag cpzz, Map<Instant, Integer> tsToIdx) {
         try {
-            // Reconstruct DetectedPattern from signal data
-            DetectedPattern reconstructed = DetectedPattern.builder()
-                    .patternType(sig.getPatternType())
-                    .bullish(sig.getDirection() == TradeDirection.LONG)
-                    .keyLevel(sig.getNeckline().doubleValue())
-                    .keyLevelTime(sig.getSignalTime())
-                    .ownTarget(sig.getTarget().doubleValue())
-                    .stopLoss(sig.getStopLoss().doubleValue())
-                    .pivotP0(sig.getPivotP0() != null ? sig.getPivotP0().doubleValue() : 0)
-                    .pivotP1(sig.getPivotP1() != null ? sig.getPivotP1().doubleValue() : 0)
-                    .pivotP2(sig.getPivotP2() != null ? sig.getPivotP2().doubleValue() : 0)
-                    .pivotP3(sig.getPivotP3() != null ? sig.getPivotP3().doubleValue() : null)
-                    .patternHeight(sig.getPatternHeight().doubleValue())
-                    .atr(0.0)  // Will be computed from indicators
-                    .rsiAtP0(0.0)
-                    .rsiAtP1(0.0)
-                    .rsiAtP2(0.0)
-                    .macdHistAtP1(0.0)
-                    .macdHistAtP2(0.0)
-                    .stochRsiK(0.0)
-                    .dailyRsi(0.0)
-                    .build();
-
-            // Find the detection bar index (closest to signal time)
-            int detectionBarIdx = bars.size() - 1;
-            if (tsToIdx != null) {
-                Integer idx = tsToIdx.get(sig.getSignalTime());
-                if (idx != null) {
-                    detectionBarIdx = idx;
-                }
-            }
-
-            // Get pivots from CandidatePivotZigZag
-            List<ZigZagPoint> pivots = cpzz != null ? cpzz.getConfirmedPivots() : new ArrayList<>();
-
-            // Build BarSeries-like view for feature extractor
-            // Create a minimal BarSeries wrapper if needed
+            // Build BarSeries-like view for feature extractor and re-detection
             org.ta4j.core.BaseBarSeries series = new org.ta4j.core.BaseBarSeries("sim", bars);
 
-            // Extract features
+            // Get pivots with trailing extreme for re-detection
+            List<ZigZagPoint> pivotsWithTrailingExtreme = cpzz != null
+                ? cpzz.getPivotsWithTrailingExtreme(bars.get(bars.size() - 1))
+                : new ArrayList<>();
+
+            // Find the matching pattern from re-detection
+            java.util.Optional<DetectedPattern> matched = dtbHnsCandidateDetector.findMatchingPattern(
+                    series, pivotsWithTrailingExtreme, atrArr, rsiValues, macdHistArr, stochRsiK, tsToIdx,
+                    sig.getPatternType(),
+                    sig.getDirection() == TradeDirection.LONG,
+                    sig.getPivotP0() != null ? sig.getPivotP0().doubleValue() : 0,
+                    sig.getPivotP1() != null ? sig.getPivotP1().doubleValue() : 0,
+                    sig.getPivotP2() != null ? sig.getPivotP2().doubleValue() : 0,
+                    sig.getPivotP3() != null ? sig.getPivotP3().doubleValue() : null);
+
+            if (matched.isEmpty()) {
+                log.warn("[SimDTB] Pattern re-detect failed for {} {} at entry confirmation — failing open",
+                        sig.getSymbol(), sig.getPatternType());
+                return null;  // Can't score, allow entry (fail-open)
+            }
+
+            DetectedPattern reDetected = matched.get();
+            int detectionBarIdx = tsToIdx != null
+                ? tsToIdx.getOrDefault(reDetected.getKeyLevelTime(), bars.size() - 1)
+                : bars.size() - 1;
+
+            // Get confirmed pivots for feature extraction
+            List<ZigZagPoint> confirmedPivots = cpzz != null ? cpzz.getConfirmedPivots() : new ArrayList<>();
+
+            // Extract features from re-detected pattern
             double[] features;
             try {
-                features = featureExtractor.extract(series, reconstructed, pivots, detectionBarIdx,
+                features = featureExtractor.extract(series, reDetected, confirmedPivots, detectionBarIdx,
                         atrArr, rsiValues, macdHistArr, stochRsiK);
             } catch (Exception ex) {
                 log.warn("[SimDTB] Feature extraction failed for {} at entry confirmation: {}", sig.getSymbol(), ex.toString());
@@ -642,5 +644,18 @@ public class DtbSimulationStrategy implements SimulationStrategy {
         return sig.getDirection() == TradeDirection.LONG
                 ? (exitPrice - entry) / entry * 100
                 : (entry - exitPrice) / entry * 100;
+    }
+
+    /**
+     * Serialize DetectedPattern to JSON for audit trail storage.
+     * Logs a warning and returns null on serialization failure — does not fail the signal.
+     */
+    private String serializeDetectedPattern(DetectedPattern pattern) {
+        try {
+            return objectMapper.writeValueAsString(pattern);
+        } catch (Exception e) {
+            log.warn("[SimDTB] Failed to serialize DetectedPattern to JSON: {}", e.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/com/dtech/kitecon/trade/entity/TradeSignal.java
+++ b/src/main/java/com/dtech/kitecon/trade/entity/TradeSignal.java
@@ -142,6 +142,9 @@ public class TradeSignal {
     @Column
     private BigDecimal pivotP3;
 
+    @Column(columnDefinition = "TEXT")
+    private String featureSnapshotJson;
+
     @PrePersist
     void prePersist() {
         createdAt = updatedAt = Instant.now();

--- a/src/main/java/com/dtech/kitecon/trade/service/TradeEntryHandler.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/TradeEntryHandler.java
@@ -78,6 +78,7 @@ public class TradeEntryHandler {
     private final InstrumentRepository instrumentRepository;
     private final DtbHnsFeatureExtractor featureExtractor;
     private final com.dtech.kitecon.backtest.PatternComboBacktestService patternComboBacktestService;
+    private final com.dtech.ta.patterns.DtbHnsCandidateDetector dtbHnsCandidateDetector;
 
     @Transactional
     public void handle(TradeSignal signal, boolean dryRun) {
@@ -338,8 +339,8 @@ public class TradeEntryHandler {
     }
 
     /**
-     * Reconstructs DetectedPattern + pivots + indicator arrays from signal state,
-     * runs feature extraction, scores via the DTB+HNS XGBoost service.
+     * Re-detects the DTB/HNS pattern at inference time to populate all indicator-derived fields,
+     * then extracts features and scores via the DTB+HNS XGBoost service.
      * Returns true if score >= threshold OR service unavailable (fail-open).
      * Returns false only if score is present and below threshold.
      */
@@ -353,29 +354,43 @@ public class TradeEntryHandler {
             double[] macdHistArr = patternComboBacktestService.computeMacdHistPublic(series);
             double[] stochRsiK = patternComboBacktestService.computeStochRsiKPublic(rsiValues);
 
-            // Pivots from confirmed-only ZigZag (live doesn't carry IncrementalZigZag state per symbol).
-            // For DTB/HNS scoring at entry-confirm, the structural pivots are what matters; trailing extreme not needed here.
+            // Build timestamp-to-index map for re-detection
+            java.util.Map<Instant, Integer> tsToIdx = new java.util.HashMap<>();
+            for (int i = 0; i < bars.size(); i++) {
+                tsToIdx.put(bars.get(i).getEndTime(), i);
+            }
+
+            // Build CandidatePivotZigZag for trailing-extreme parity with training/sim
             com.dtech.chartpattern.zigzag.ZigZagParams params = zigZagService.resolveParams(signal.getSymbol(), Interval.OneHour);
-            java.util.List<ZigZagPoint> pivots = zigZagService.detect(series, params);
+            com.dtech.kitecon.simulation.CandidatePivotZigZag cpzz =
+                    new com.dtech.kitecon.simulation.CandidatePivotZigZag(params);
+            for (int i = 0; i < series.getBarCount(); i++) {
+                cpzz.processBar(series, i);
+            }
+            Bar latest = series.getBar(series.getBarCount() - 1);
+            java.util.List<ZigZagPoint> pivots = cpzz.getPivotsWithTrailingExtreme(latest);
 
-            // Reconstruct DetectedPattern from signal's stored pivot fields
-            DetectedPattern reconstructed = DetectedPattern.builder()
-                    .patternType(signal.getPatternType())
-                    .bullish(signal.getDirection() == TradeDirection.LONG)
-                    .keyLevel(signal.getNeckline() != null ? signal.getNeckline().doubleValue() : 0)
-                    .keyLevelTime(signal.getSignalTime())
-                    .ownTarget(signal.getTarget() != null ? signal.getTarget().doubleValue() : 0)
-                    .stopLoss(signal.getStopLoss() != null ? signal.getStopLoss().doubleValue() : 0)
-                    .pivotP0(signal.getPivotP0() != null ? signal.getPivotP0().doubleValue() : 0)
-                    .pivotP1(signal.getPivotP1() != null ? signal.getPivotP1().doubleValue() : 0)
-                    .pivotP2(signal.getPivotP2() != null ? signal.getPivotP2().doubleValue() : 0)
-                    .pivotP3(signal.getPivotP3() != null ? signal.getPivotP3().doubleValue() : null)
-                    .build();
+            // Find the matching pattern from live re-detection
+            java.util.Optional<DetectedPattern> matched = dtbHnsCandidateDetector.findMatchingPattern(
+                    series, pivots, atrArr, rsiValues, macdHistArr, stochRsiK, tsToIdx,
+                    signal.getPatternType(),
+                    signal.getDirection() == TradeDirection.LONG,
+                    signal.getPivotP0() != null ? signal.getPivotP0().doubleValue() : 0,
+                    signal.getPivotP1() != null ? signal.getPivotP1().doubleValue() : 0,
+                    signal.getPivotP2() != null ? signal.getPivotP2().doubleValue() : 0,
+                    signal.getPivotP3() != null ? signal.getPivotP3().doubleValue() : null);
 
-            int currentBarIdx = series.getBarCount() - 1;
+            if (matched.isEmpty()) {
+                log.warn("[EntryHandler] DTB/HNS pattern re-detect failed for signal {} {} — failing open",
+                        signal.getId(), signal.getSymbol());
+                return true;  // can't score, allow entry
+            }
+
+            DetectedPattern reDetected = matched.get();
+            int currentBarIdx = tsToIdx.getOrDefault(reDetected.getKeyLevelTime(), series.getBarCount() - 1);
 
             double[] features = featureExtractor.extract(
-                    series, reconstructed, pivots, currentBarIdx,
+                    series, reDetected, pivots, currentBarIdx,
                     atrArr, rsiValues, macdHistArr, stochRsiK);
 
             java.util.OptionalDouble scoreOpt = tradeFilterClient.scoreDtbHns(features);

--- a/src/main/java/com/dtech/ta/patterns/DtbHnsCandidateDetector.java
+++ b/src/main/java/com/dtech/ta/patterns/DtbHnsCandidateDetector.java
@@ -103,6 +103,55 @@ public class DtbHnsCandidateDetector {
         return results;
     }
 
+    /**
+     * Helper method to find a matching pattern that corresponds to a trade signal.
+     * Used during inference to re-detect the pattern with full indicator context.
+     *
+     * @param series BarSeries for context
+     * @param pivotsWithTrailingExtreme confirmed pivots + trailing extreme candidate
+     * @param atrArr array of ATR values indexed by bar
+     * @param rsiValues array of RSI values indexed by bar
+     * @param macdHistArr array of MACD histogram values indexed by bar
+     * @param stochRsiK array of Stoch RSI K values indexed by bar
+     * @param tsToIdx map from bar timestamp to bar index
+     * @param patternType expected pattern type (e.g., "DOUBLE_BOTTOM")
+     * @param bullish expected direction (true for LONG, false for SHORT)
+     * @param pivotP0 expected P0 price (tolerance: 0.5%)
+     * @param pivotP1 expected P1 price (tolerance: 0.5%)
+     * @param pivotP2 expected P2 price (tolerance: 0.5%)
+     * @param pivotP3 expected P3 price for HNS (tolerance: 0.5%), nullable
+     * @return Optional containing the matching DetectedPattern with all indicator fields populated
+     */
+    public java.util.Optional<DetectedPattern> findMatchingPattern(
+            BarSeries series,
+            java.util.List<ZigZagPoint> pivotsWithTrailingExtreme,
+            double[] atrArr, double[] rsiValues, double[] macdHistArr, double[] stochRsiK,
+            java.util.Map<java.time.Instant, Integer> tsToIdx,
+            String patternType, boolean bullish,
+            double pivotP0, double pivotP1, double pivotP2, Double pivotP3) {
+
+        java.util.List<DetectedPattern> all = detect(series, pivotsWithTrailingExtreme,
+                atrArr, rsiValues, macdHistArr, stochRsiK, tsToIdx);
+
+        return all.stream()
+            .filter(p -> patternType.equals(p.getPatternType()))
+            .filter(p -> p.isBullish() == bullish)
+            .filter(p -> matchesPivot(p.getPivotP0(), pivotP0)
+                      && matchesPivot(p.getPivotP1(), pivotP1)
+                      && matchesPivot(p.getPivotP2(), pivotP2)
+                      && (pivotP3 == null || (p.getPivotP3() != null && matchesPivot(p.getPivotP3(), pivotP3))))
+            .findFirst();
+    }
+
+    /**
+     * Check if two pivot prices match within 0.5% tolerance.
+     * Handles both zero and non-zero values.
+     */
+    private static boolean matchesPivot(double a, double b) {
+        if (b == 0) return Math.abs(a) < 1e-9;  // both zero
+        return Math.abs(a - b) / Math.abs(b) < 0.005;  // 0.5% tolerance
+    }
+
     // ────────────────────────────────────────────────────────────────
     // DOUBLE_BOTTOM / DOUBLE_TOP
     // ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

At DTB/HNS ML gate time, `DetectedPattern` was reconstructed from stored `TradeSignal` fields with zero values for all indicator fields (`rsiAtP0/P1/P2`, `macdHistAtP1/P2`, `stochRsiK`, `atr`). The XGBoost model trained on real indicator values received all-zeros at inference, biasing scores systematically low (APLAPOLLO=0.237, NBCC=0.432 on valid setups).

## Fix

- **Re-detect at inference**: `TradeEntryHandler.applyDtbHnsMLGate` and `DtbSimulationStrategy.applyDtbHnsMLGate` now rebuild `CandidatePivotZigZag` from the live `BarSeries` and call `dtbHnsCandidateDetector.findMatchingPattern()` — matching by pattern type + pivot prices within 0.5% — to get a fully-populated `DetectedPattern` with real indicator values.
- **JSON snapshot**: `featureSnapshotJson` (TEXT column on `TradeSignal`) serialized from `DetectedPattern` at signal-creation time in `PatternScanService` and `DtbSimulationStrategy`.

## Files changed

- `DtbHnsCandidateDetector.java` — `findMatchingPattern()` helper
- `TradeEntryHandler.java` — re-detect via CandidatePivotZigZag
- `DtbSimulationStrategy.java` — same + featureSnapshotJson serialization
- `PatternScanService.java` — featureSnapshotJson at signal creation
- `PatternDto.java`, `PatternComboScannerService.java`, `TradeSignal.java` — supporting changes

Closes #179