### PR TITLE
chore: ignore local training data dirs in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,10 @@ hs_err_pid*.log
 
 # Kotlin compiler temp
 .kotlin/
+
+# Local training data outputs (regenerated; never commit)
+candidate_pivot_train_data/
+clean_impulse_train_data/
+zigzag_pivots/
+elliott_train_data.tar.xz
+deploy_artifacts/


### PR DESCRIPTION
Adds gitignore entries for: candidate_pivot_train_data/, clean_impulse_train_data/, zigzag_pivots/, elliott_train_data.tar.xz, deploy_artifacts/ — these are generated locally and should never be committed.