### PR TITLE
fix: register JavaTimeModule on ObjectMapper — fix Instant serialization in pattern scanner

### DIFF
--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternScanService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternScanService.java
@@ -34,7 +34,9 @@ public class PatternScanService {
     private final InstrumentRepository instrumentRepository;
     private final DataFetchService dataFetchService;
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
+            .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
     private static final List<String> NIFTY50 = List.of(
         "RELIANCE", "TCS", "HDFCBANK", "BHARTIARTL", "ICICIBANK",

--- a/src/main/java/com/dtech/kitecon/simulation/strategy/DtbSimulationStrategy.java
+++ b/src/main/java/com/dtech/kitecon/simulation/strategy/DtbSimulationStrategy.java
@@ -54,7 +54,9 @@ public class DtbSimulationStrategy implements SimulationStrategy {
     private final DtbHnsFeatureExtractor featureExtractor;
     private final DtbHnsCandidateDetector dtbHnsCandidateDetector;
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
+            .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
     @Value("${trade.filter.threshold:0.82}")
     private double mlThreshold;


### PR DESCRIPTION
DetectedPattern.keyLevelTime (Instant) was failing JSON serialization every scan cycle, flooding logs with WARNs. Fix: registerModule(JavaTimeModule) + disable WRITE_DATES_AS_TIMESTAMPS on static ObjectMappers in PatternScanService and DtbSimulationStrategy.