### PR TITLE
fix: skip impulse ML gate for DTB/HNS signals — they have their own gate

### DIFF
--- a/src/main/java/com/dtech/kitecon/trade/service/TradeEntryHandler.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/TradeEntryHandler.java
@@ -101,7 +101,11 @@ public class TradeEntryHandler {
         BarSeries series = getBarSeriesForSignal(signal);
         boolean entryTriggered = isEntryTriggered(signal, ltp, series);
 
-        if (entryTriggered) {
+        String pt = signal.getPatternType();
+        boolean isDtbOrHns = "DOUBLE_BOTTOM".equals(pt) || "DOUBLE_TOP".equals(pt)
+                         || "HNS_BULL".equals(pt) || "HNS_BEAR".equals(pt);
+
+        if (entryTriggered && !isDtbOrHns) {
             double score = scoreMlAtEntry(signal);
             signal.setMlScore(BigDecimal.valueOf(score).setScale(4, java.math.RoundingMode.HALF_UP));
             if (score < mlFilterThreshold) {


### PR DESCRIPTION
DTB/HNS signals were passing their own XGBoost gate (threshold=0.85) inside tryConfirmDtbHnsEntry, then hitting the impulse ML filter (threshold=0.81, trained on impulse features) which gave garbage scores and expired every DTB/HNS entry. Fix: add isDtbOrHns guard so the impulse gate only runs for non-DTB/HNS patterns.