### PR TITLE
fix: use structural SL from detector for DTB/HNS — prevents immediate stop-outs

### DIFF
--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
@@ -171,7 +171,11 @@ public class PatternComboScannerService {
         double atr = pattern.getAtr();
 
         BigDecimal stopLoss;
-        if (pattern.isBullish()) {
+        boolean isDtbOrHns = "DOUBLE_BOTTOM".equals(pt) || "DOUBLE_TOP".equals(pt)
+                || "HNS_BULL".equals(pt) || "HNS_BEAR".equals(pt);
+        if (isDtbOrHns) {
+            stopLoss = BigDecimal.valueOf(pattern.getStopLoss());
+        } else if (pattern.isBullish()) {
             stopLoss = keyLevel.subtract(BigDecimal.valueOf(2.0 * atr));
         } else {
             stopLoss = keyLevel.add(BigDecimal.valueOf(2.0 * atr));

--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternDto.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternDto.java
@@ -14,6 +14,7 @@ public class PatternDto {
     double target;            // measured-move target
     double patternHeight;
     double atr;
+    double stopLoss;          // structural stop loss (for DTB/HNS patterns)
     double rsiAtP1;
     double rsiAtP2;
     double rrRatio;


### PR DESCRIPTION
ATR-based SL was wrong for DTB/HNS after reversal-candle entry shifts the entryPrice away from keyLevel. APLAPOLLO LONG had SL above entry; MANAPPURAM SHORT had SL below entry — both stopped out immediately at zero movement. Fix: use pattern.getStopLoss() (structural: min of lows for DTB, head level for HNS) for DTB/HNS patterns; keep ATR-based SL for Triangle/TLB/etc.