### PR TITLE
fix: scope impulse ML gate to IMPULSE strategy only

### DIFF
--- a/src/main/java/com/dtech/kitecon/trade/service/TradeEntryHandler.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/TradeEntryHandler.java
@@ -8,6 +8,7 @@ import com.dtech.kitecon.trade.entity.TradeExecution;
 import com.dtech.kitecon.trade.entity.TradeMonitorLog;
 import com.dtech.kitecon.trade.entity.TradeSignal;
 import com.dtech.kitecon.trade.enums.MonitorAction;
+import com.dtech.kitecon.trade.enums.StrategyType;
 import com.dtech.kitecon.trade.enums.TradeDirection;
 import com.dtech.kitecon.trade.enums.TradeStatus;
 import com.dtech.kitecon.trade.repository.TradeExecutionRepository;
@@ -101,11 +102,9 @@ public class TradeEntryHandler {
         BarSeries series = getBarSeriesForSignal(signal);
         boolean entryTriggered = isEntryTriggered(signal, ltp, series);
 
-        String pt = signal.getPatternType();
-        boolean isDtbOrHns = "DOUBLE_BOTTOM".equals(pt) || "DOUBLE_TOP".equals(pt)
-                         || "HNS_BULL".equals(pt) || "HNS_BEAR".equals(pt);
+        boolean isImpulse = signal.getStrategyType() == StrategyType.IMPULSE;
 
-        if (entryTriggered && !isDtbOrHns) {
+        if (entryTriggered && isImpulse) {
             double score = scoreMlAtEntry(signal);
             signal.setMlScore(BigDecimal.valueOf(score).setScale(4, java.math.RoundingMode.HALF_UP));
             if (score < mlFilterThreshold) {


### PR DESCRIPTION
## Summary
- Impulse ML gate in `TradeEntryHandler` was running on Triangle, TLB, and Flag signals — all non-impulse patterns from the pattern scanner
- Replaced brittle pattern-type string list (`!isDtbOrHns`) with `strategyType == IMPULSE` check
- All pattern-scanner signals have `strategyType=DTB` by entity default, so they are now cleanly excluded

Closes #185

## Test plan
- [ ] Deploy to prod; verify Triangle/TLB entries are no longer blocked by the impulse ML score log line
- [ ] Verify IMPULSE-strategy signals still go through `scoreMlAtEntry()` (log shows `ML filter rejected` or proceeds)
- [ ] Confirm DTB/HNS signals still go through their own `applyDtbHnsMLGate()` path (unchanged at line ~213)

🤖 Generated with [Claude Code](https://claude.com/claude-code)