### PR TITLE
fix: compute structural SL for DTB/HNS signals instead of using 0

### DIFF
--- a/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
+++ b/src/main/java/com/dtech/kitecon/patternscanner/PatternComboScannerService.java
@@ -174,7 +174,16 @@ public class PatternComboScannerService {
         boolean isDtbOrHns = "DOUBLE_BOTTOM".equals(pt) || "DOUBLE_TOP".equals(pt)
                 || "HNS_BULL".equals(pt) || "HNS_BEAR".equals(pt);
         if (isDtbOrHns) {
-            stopLoss = BigDecimal.valueOf(pattern.getStopLoss());
+            double ph = pattern.getPatternHeight();
+            if ("HNS_BULL".equals(pt)) {
+                stopLoss = keyLevel.subtract(BigDecimal.valueOf(ph * 0.5));
+            } else if ("HNS_BEAR".equals(pt)) {
+                stopLoss = keyLevel.add(BigDecimal.valueOf(ph * 0.5));
+            } else if (pattern.isBullish()) {
+                stopLoss = keyLevel.subtract(BigDecimal.valueOf(ph));
+            } else {
+                stopLoss = keyLevel.add(BigDecimal.valueOf(ph));
+            }
         } else if (pattern.isBullish()) {
             stopLoss = keyLevel.subtract(BigDecimal.valueOf(2.0 * atr));
         } else {


### PR DESCRIPTION
## Summary

- DTB/HNS signals were saved with `stop_loss=0` because the watching scan returns `stopLoss=0` in `DetectedPattern`, and `createSignalForPattern()` used it directly
- SHORT trades (DOUBLE_TOP, HNS_BEAR) with SL=0 exited immediately on the first monitor tick (`ltp >= 0` is always true)
- 8 SHORT paper trades were already affected; 2 active LONG trades manually patched in DB

## Fix

Compute SL from `keyLevel` (neckline) + `patternHeight` for DTB/HNS patterns, matching the logic in `DtbSimulationStrategy`:
- DOUBLE_BOTTOM: `keyLevel - patternHeight`
- DOUBLE_TOP: `keyLevel + patternHeight`
- HNS_BULL: `keyLevel - 0.5 × patternHeight`
- HNS_BEAR: `keyLevel + 0.5 × patternHeight`

## Test plan

- [ ] Scanner creates new DOUBLE_TOP signal and verify stop_loss > entry_price
- [ ] Scanner creates new HNS_BEAR signal and verify stop_loss = keyLevel + 0.5×patternHeight
- [ ] DOUBLE_TOP SHORT trade does NOT exit immediately on next monitor tick

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)