### PR TITLE
fix: prevent live Zerodha exits on DTB paper trades

### DIFF
--- a/src/main/java/com/dtech/kitecon/trade/service/PaperOrderExecutionService.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/PaperOrderExecutionService.java
@@ -126,6 +126,10 @@ public class PaperOrderExecutionService {
                         resolved.getTradingSymbol(), e.getMessage(), e);
                 // Order stays as paper trade — don't crash the flow
             }
+        } else {
+            // Not a live order — explicitly mark as paper so exit doesn't fire real orders
+            order.setPaperTrade(true);
+            tradeOrderRepository.save(order);
         }
 
         return order;


### PR DESCRIPTION
## Summary
- DTB paper trades were leaking live exit orders to Zerodha because `TradeOrder.paperTrade` (primitive `boolean`) defaulted to `false`
- The exit guard `!order.isPaperTrade()` evaluated to `true`, firing real broker exits for paper trades
- Fix: explicitly set `paperTrade=true` and persist when we don't go live (entry side was already correctly guarded)

## Test plan
- [ ] After deploy, monitor logs for any `[LiveOrder] EXIT PLACED` lines on DTB signals — should be zero
- [ ] Paper DTB trades should still log `[PaperOrder] EXIT` only

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)