### PR TITLE
fix: TradeOrdersPage runtime ReferenceError on showRealisedPnl

### DIFF
--- a/ui/chart-draw-app/src/tradeMonitor/pages/TradeOrdersPage.tsx
+++ b/ui/chart-draw-app/src/tradeMonitor/pages/TradeOrdersPage.tsx
@@ -224,6 +224,7 @@ const TradeOrdersPage: React.FC = () => {
   const unrealisedPnl = summary?.unrealisedPnlInr || 0;
   const totalPnl = summary?.totalPnlInr || 0;
   const winRate = summary?.winRatePct || 0;
+  const showRealisedPnl = filterStatus !== "OPEN";
 
   return (
     <div style={containerStyle}>
@@ -391,8 +392,6 @@ const TradeOrdersPage: React.FC = () => {
           {scanning ? "Scanning..." : "Scan Now"}
         </button>
       </div>
-
-      const showRealisedPnl = filterStatus !== "OPEN";
 
       <table style={tableStyle}>
         <thead>


### PR DESCRIPTION
## Summary
- `const showRealisedPnl = filterStatus !== "OPEN";` was inside JSX (between two elements), silently dropped by the build, leaving downstream references undefined at runtime
- Hoisted the declaration above `return (` next to the other derived locals

## Test plan
- [ ] After deploy + CloudFront invalidation, reload `/trade-orders` and confirm no ReferenceError in browser console
- [ ] Toggle Status filter (OPEN vs ALL/CLOSED) and confirm the P&L column appears/disappears as expected

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)