### PR TITLE
fix(dtb): higher-top SL + 1-OTM strike + close-basis stop

### DIFF
--- a/src/main/java/com/dtech/kitecon/trade/service/InstrumentResolverService.java
+++ b/src/main/java/com/dtech/kitecon/trade/service/InstrumentResolverService.java
@@ -128,19 +128,29 @@ public class InstrumentResolverService {
             log.info("[InstrumentResolver] {} expiry week ({}) — using ATM instead of {}% OTM",
                     symbol, nearestExpiry.toLocalDate(), otmPct * 100);
         }
-        // For OTM: offset the target strike from LTP
-        double targetStrike = ltp;
-        if (effectiveOtmPct > 0) {
-            targetStrike = direction == TradeDirection.LONG
-                    ? ltp * (1 + effectiveOtmPct)   // CE strike above LTP
-                    : ltp * (1 - effectiveOtmPct);  // PE strike below LTP
-        }
-        final double ts = targetStrike;
+
+        // Default to 1-OTM strike (the nearest strike on the OTM side of LTP):
+        //   LONG  / CE → first strike >= LTP
+        //   SHORT / PE → first strike <= LTP
+        // Picking the absolute-closest strike can land ITM and load the option with
+        // intrinsic value that destroys risk:reward.
+        final boolean otmHigher = direction == TradeDirection.LONG;
         Instrument atm = options.stream()
                 .filter(i -> nearestExpiry.equals(i.getExpiry()))
                 .filter(i -> i.getStrike() != null)
-                .min(Comparator.comparingDouble(i -> Math.abs(Double.parseDouble(i.getStrike()) - ts)))
-                .orElseThrow(() -> new RuntimeException("No option found for: " + symbol + " near strike " + ts));
+                .filter(i -> {
+                    double s = Double.parseDouble(i.getStrike());
+                    if (effectiveOtmPct > 0) {
+                        // Caller asked for explicit OTM offset — strike must be at least that far OTM
+                        double minOffset = ltp * effectiveOtmPct;
+                        return otmHigher ? s >= ltp + minOffset : s <= ltp - minOffset;
+                    }
+                    // Default 1-OTM: strike strictly on the OTM side of LTP
+                    return otmHigher ? s >= ltp : s <= ltp;
+                })
+                .min(Comparator.comparingDouble(i -> Math.abs(Double.parseDouble(i.getStrike()) - ltp)))
+                .orElseThrow(() -> new RuntimeException("No OTM " + optionType + " option found for: " + symbol
+                        + " near LTP " + ltp + " (otmPct=" + effectiveOtmPct + ")"));
 
         return ResolvedInstrument.builder()
                 .tradingSymbol(atm.getTradingsymbol())

--- a/src/main/java/com/dtech/kitecon/trade/strategy/DtbExitStrategy.java
+++ b/src/main/java/com/dtech/kitecon/trade/strategy/DtbExitStrategy.java
@@ -1,28 +1,73 @@
 package com.dtech.kitecon.trade.strategy;
 
+import com.dtech.algo.series.Interval;
+import com.dtech.chartpattern.zigzag.ZigZagService;
+import com.dtech.kitecon.data.Instrument;
+import com.dtech.kitecon.repository.InstrumentRepository;
 import com.dtech.kitecon.trade.entity.TradeSignal;
 import com.dtech.kitecon.trade.enums.ExitReason;
 import com.dtech.kitecon.trade.enums.TradeDirection;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.ta4j.core.Bar;
+import org.ta4j.core.BarSeries;
 
 import java.math.BigDecimal;
 
 @Component
+@Slf4j
 @RequiredArgsConstructor
 public class DtbExitStrategy implements ExitStrategy {
+
+    private final ZigZagService zigZagService;
+    private final InstrumentRepository instrumentRepository;
+
     @Override
     public ExitDecision evaluate(TradeSignal signal, ExitContext ctx) {
         BigDecimal underlyingLtp = ctx.underlyingLtp();
         BigDecimal currentLtp = ctx.ltp();
         boolean isLong = signal.getDirection() == TradeDirection.LONG;
-        if (isLong) {
-            if (underlyingLtp.compareTo(signal.getStopLoss()) <= 0) return ExitDecision.exit(ExitReason.STOP_HIT, currentLtp);
-            if (underlyingLtp.compareTo(signal.getTarget()) >= 0) return ExitDecision.exit(ExitReason.TARGET_HIT, currentLtp);
-        } else {
-            if (underlyingLtp.compareTo(signal.getStopLoss()) >= 0) return ExitDecision.exit(ExitReason.STOP_HIT, currentLtp);
-            if (underlyingLtp.compareTo(signal.getTarget()) <= 0) return ExitDecision.exit(ExitReason.TARGET_HIT, currentLtp);
+
+        // Stop-loss is evaluated on a CLOSING basis: only fires when the latest
+        // completed bar at the signal's timeframe (e.g. hourly) closes through
+        // the SL level. Wicks that pierce intra-bar are ignored.
+        BigDecimal stopBasis = lastCompletedBarClose(signal);
+        if (stopBasis != null) {
+            if (isLong && stopBasis.compareTo(signal.getStopLoss()) <= 0) {
+                return ExitDecision.exit(ExitReason.STOP_HIT, currentLtp);
+            }
+            if (!isLong && stopBasis.compareTo(signal.getStopLoss()) >= 0) {
+                return ExitDecision.exit(ExitReason.STOP_HIT, currentLtp);
+            }
+        }
+
+        // Target is evaluated on touch — lock in profit as soon as price reaches it.
+        if (isLong && underlyingLtp.compareTo(signal.getTarget()) >= 0) {
+            return ExitDecision.exit(ExitReason.TARGET_HIT, currentLtp);
+        }
+        if (!isLong && underlyingLtp.compareTo(signal.getTarget()) <= 0) {
+            return ExitDecision.exit(ExitReason.TARGET_HIT, currentLtp);
         }
         return ExitDecision.hold();
+    }
+
+    private BigDecimal lastCompletedBarClose(TradeSignal signal) {
+        try {
+            String tf = signal.getTimeframe();
+            if (tf == null) return null;
+            Interval interval = Interval.fromUiKey(tf);
+            Instrument instrument = instrumentRepository.findByTradingsymbolAndExchangeIn(
+                    signal.getSymbol(), new String[]{"NSE", "BSE"});
+            if (instrument == null) return null;
+            BarSeries series = zigZagService.getBarSeries(signal.getSymbol(), instrument, interval);
+            if (series == null || series.getBarCount() == 0) return null;
+            Bar lastBar = series.getLastBar();
+            return BigDecimal.valueOf(lastBar.getClosePrice().doubleValue());
+        } catch (Exception e) {
+            log.debug("[DtbExit] Could not load last bar close for signal {} {}: {}",
+                    signal.getId(), signal.getSymbol(), e.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/com/dtech/ta/patterns/DtbHnsCandidateDetector.java
+++ b/src/main/java/com/dtech/ta/patterns/DtbHnsCandidateDetector.java
@@ -188,7 +188,11 @@ public class DtbHnsCandidateDetector {
         Integer p1Idx = tsToIdx.get(p1.getTimestamp());
         if (p1Idx == null || p1Idx >= rsiValues.length) p1Idx = p0Idx;
 
-        double patternHeight = Math.abs(v1 - Math.min(v0, v2));
+        // Structural extreme that invalidates the pattern:
+        //   DOUBLE_BOTTOM (bullish): the LOWER of the two bottoms — SL placed below it.
+        //   DOUBLE_TOP    (bearish): the HIGHER of the two tops    — SL placed above it.
+        double structuralExtreme = bullish ? Math.min(v0, v2) : Math.max(v0, v2);
+        double patternHeight = Math.abs(v1 - structuralExtreme);
         double target = bullish ? v1 + patternHeight : v1 - patternHeight;
 
         double rsiP1 = p1Idx < rsiValues.length ? rsiValues[p1Idx] : 0;
@@ -197,7 +201,7 @@ public class DtbHnsCandidateDetector {
         double atrAtP0 = p0Idx < atrArr.length ? atrArr[p0Idx] : 0;
         double stochK = p0Idx < stochRsiK.length ? stochRsiK[p0Idx] : 0;
 
-        double stopLoss = Math.min(v0, v2);  // DTB: min of two lows (DOUBLE_BOTTOM/DOUBLE_TOP)
+        double stopLoss = structuralExtreme;
 
         results.add(DetectedPattern.builder()
                 .patternType(bullish ? "DOUBLE_BOTTOM" : "DOUBLE_TOP")


### PR DESCRIPTION
## Summary
Three correlated DTB live-trade defects, fixed together because they all surfaced from the same PAYTM SHORT investigation.

1. **#198 — DOUBLE_TOP SL at lower top instead of higher top**: `min(v0, v2)` used for both bullish and bearish; for DOUBLE_TOP this picks the lower top so SL sits inside the pattern and fires immediately on a return to the higher top. Now `bullish ? min : max`.
2. **#199 — Strike picker lands ITM**: closest-strike selection without an OTM-side filter. Now picks first strike on the OTM side of LTP (LONG → ≥ LTP, SHORT → ≤ LTP).
3. **#200 — SL on LTP touch**: SL now evaluates against the close of the latest completed bar at `signal.getTimeframe()`. Target stays touch-based.

## Test plan
- [x] Compiles cleanly
- [ ] After deploy: confirm a fresh DOUBLE_TOP SHORT signal places SL above the higher of P0/P2
- [ ] Confirm a fresh DTB SHORT enters on a PE strike ≤ underlying LTP (not above)
- [ ] Confirm SL doesn't fire on intra-bar wicks that don't carry to candle close

## Already done outside this PR
- PAYTM signal 15647 in production DB has had `stop_loss` patched from 1115.80 → 1123.00 (= P2) so the existing trade gets correct invalidation pending deploy.

Closes #198 #199 #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)