### PR TITLE
feat(aitrader): trader annotations + symbol thesis fed into AI prompts

### DIFF
--- a/src/main/java/com/dtech/aitrader/annotation/dto/AnnotationBundleDto.java
+++ b/src/main/java/com/dtech/aitrader/annotation/dto/AnnotationBundleDto.java
@@ -1,0 +1,25 @@
+package com.dtech.aitrader.annotation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AnnotationBundleDto {
+    private SymbolThesisDto thesis;
+    private List<DrawingAnnotationDto> annotations;
+
+    public boolean isEmpty() {
+        boolean noThesis = thesis == null
+                || (thesis.getThesisText() == null || thesis.getThesisText().isBlank())
+                && thesis.getBias() == null && thesis.getRegime() == null;
+        boolean noAnn = annotations == null || annotations.isEmpty();
+        return noThesis && noAnn;
+    }
+}

--- a/src/main/java/com/dtech/aitrader/annotation/dto/DrawingAnnotationDto.java
+++ b/src/main/java/com/dtech/aitrader/annotation/dto/DrawingAnnotationDto.java
@@ -1,0 +1,28 @@
+package com.dtech.aitrader.annotation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DrawingAnnotationDto {
+    private Long id;
+    private String tabUuid;
+    private String symbol;
+    private String interval;
+    private String drawingId;
+    private String intent;
+    private String intentParamsJson;
+    private String geometryJson;
+    private String note;
+    private Integer weight;
+    private boolean active;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/src/main/java/com/dtech/aitrader/annotation/dto/SaveAnnotationRequest.java
+++ b/src/main/java/com/dtech/aitrader/annotation/dto/SaveAnnotationRequest.java
@@ -1,0 +1,16 @@
+package com.dtech.aitrader.annotation.dto;
+
+import lombok.Data;
+
+@Data
+public class SaveAnnotationRequest {
+    private String tabUuid;
+    private String symbol;
+    private String interval;
+    private String drawingId;
+    private String intent;
+    private String intentParamsJson;
+    private String geometryJson;
+    private String note;
+    private Integer weight;
+}

--- a/src/main/java/com/dtech/aitrader/annotation/dto/SaveThesisRequest.java
+++ b/src/main/java/com/dtech/aitrader/annotation/dto/SaveThesisRequest.java
@@ -1,0 +1,13 @@
+package com.dtech.aitrader.annotation.dto;
+
+import lombok.Data;
+
+@Data
+public class SaveThesisRequest {
+    private String tabUuid;
+    private String symbol;
+    private String bias;
+    private String regime;
+    private Integer horizonDays;
+    private String thesisText;
+}

--- a/src/main/java/com/dtech/aitrader/annotation/dto/SymbolThesisDto.java
+++ b/src/main/java/com/dtech/aitrader/annotation/dto/SymbolThesisDto.java
@@ -1,0 +1,23 @@
+package com.dtech.aitrader.annotation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SymbolThesisDto {
+    private Long id;
+    private String tabUuid;
+    private String symbol;
+    private String bias;
+    private String regime;
+    private Integer horizonDays;
+    private String thesisText;
+    private Instant updatedAt;
+}

--- a/src/main/java/com/dtech/aitrader/annotation/entity/ChartDrawingAnnotation.java
+++ b/src/main/java/com/dtech/aitrader/annotation/entity/ChartDrawingAnnotation.java
@@ -1,0 +1,80 @@
+package com.dtech.aitrader.annotation.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "chart_drawing_annotation",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_drawing_user_tab_symbol_drawing",
+                columnNames = {"user_id", "tab_uuid", "symbol", "drawing_id"}))
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ChartDrawingAnnotation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "tab_uuid", nullable = false, length = 64)
+    private String tabUuid;
+
+    @Column(name = "symbol", nullable = false, length = 32)
+    private String symbol;
+
+    @Column(name = "interval_name", length = 16)
+    private String interval;
+
+    @Column(name = "drawing_id", nullable = false, length = 64)
+    private String drawingId;
+
+    @Column(name = "intent", nullable = false, length = 32)
+    private String intent;
+
+    @Lob
+    @Column(name = "intent_params_json", columnDefinition = "TEXT")
+    private String intentParamsJson;
+
+    @Lob
+    @Column(name = "geometry_json", columnDefinition = "TEXT")
+    private String geometryJson;
+
+    @Lob
+    @Column(name = "note", columnDefinition = "TEXT")
+    private String note;
+
+    @Column(name = "weight", nullable = false)
+    private Integer weight;
+
+    @Column(name = "active", nullable = false)
+    private boolean active;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        if (createdAt == null) createdAt = now;
+        updatedAt = now;
+        if (weight == null) weight = 3;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/dtech/aitrader/annotation/entity/SymbolThesis.java
+++ b/src/main/java/com/dtech/aitrader/annotation/entity/SymbolThesis.java
@@ -1,0 +1,56 @@
+package com.dtech.aitrader.annotation.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "symbol_thesis",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_thesis_user_tab_symbol",
+                columnNames = {"user_id", "tab_uuid", "symbol"}))
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SymbolThesis {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "tab_uuid", nullable = false, length = 64)
+    private String tabUuid;
+
+    @Column(name = "symbol", nullable = false, length = 32)
+    private String symbol;
+
+    @Column(name = "bias", length = 16)
+    private String bias;
+
+    @Column(name = "regime", length = 32)
+    private String regime;
+
+    @Column(name = "horizon_days")
+    private Integer horizonDays;
+
+    @Lob
+    @Column(name = "thesis_text", columnDefinition = "TEXT")
+    private String thesisText;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    @PreUpdate
+    void onSave() {
+        updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/dtech/aitrader/annotation/repository/ChartDrawingAnnotationRepository.java
+++ b/src/main/java/com/dtech/aitrader/annotation/repository/ChartDrawingAnnotationRepository.java
@@ -1,0 +1,21 @@
+package com.dtech.aitrader.annotation.repository;
+
+import com.dtech.aitrader.annotation.entity.ChartDrawingAnnotation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ChartDrawingAnnotationRepository extends JpaRepository<ChartDrawingAnnotation, Long> {
+
+    List<ChartDrawingAnnotation> findByUserIdAndTabUuidAndSymbolAndActiveTrueOrderByWeightDescUpdatedAtDesc(
+            Long userId, String tabUuid, String symbol);
+
+    List<ChartDrawingAnnotation> findByUserIdAndSymbolAndActiveTrueOrderByWeightDescUpdatedAtDesc(
+            Long userId, String symbol);
+
+    Optional<ChartDrawingAnnotation> findByUserIdAndTabUuidAndSymbolAndDrawingId(
+            Long userId, String tabUuid, String symbol, String drawingId);
+}

--- a/src/main/java/com/dtech/aitrader/annotation/repository/SymbolThesisRepository.java
+++ b/src/main/java/com/dtech/aitrader/annotation/repository/SymbolThesisRepository.java
@@ -1,0 +1,15 @@
+package com.dtech.aitrader.annotation.repository;
+
+import com.dtech.aitrader.annotation.entity.SymbolThesis;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SymbolThesisRepository extends JpaRepository<SymbolThesis, Long> {
+
+    Optional<SymbolThesis> findByUserIdAndTabUuidAndSymbol(Long userId, String tabUuid, String symbol);
+
+    Optional<SymbolThesis> findFirstByUserIdAndSymbolOrderByUpdatedAtDesc(Long userId, String symbol);
+}

--- a/src/main/java/com/dtech/aitrader/annotation/service/AnnotationBundleBuilder.java
+++ b/src/main/java/com/dtech/aitrader/annotation/service/AnnotationBundleBuilder.java
@@ -1,0 +1,163 @@
+package com.dtech.aitrader.annotation.service;
+
+import com.dtech.aitrader.annotation.dto.AnnotationBundleDto;
+import com.dtech.aitrader.annotation.dto.DrawingAnnotationDto;
+import com.dtech.aitrader.annotation.dto.SymbolThesisDto;
+import com.dtech.aitrader.annotation.entity.ChartDrawingAnnotation;
+import com.dtech.aitrader.annotation.entity.SymbolThesis;
+import com.dtech.aitrader.annotation.repository.ChartDrawingAnnotationRepository;
+import com.dtech.aitrader.annotation.repository.SymbolThesisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Builds an AnnotationBundle for injection into AI agent prompts.
+ * <p>
+ * Two scopes:
+ * - {@link #buildForLevels(Long, String, String)} — tab-scoped (Levels run is initiated from a chart on a specific tab).
+ * - {@link #buildForPattern(Long, String)} — symbol-scoped (Pattern agent fires from system events, no tab context). Picks
+ *   annotations across all tabs the user has, plus the most recent thesis row for the symbol.
+ * <p>
+ * Both also render the bundle to a prompt fragment via {@link #toPromptSection(AnnotationBundleDto)}.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AnnotationBundleBuilder {
+
+    private static final int MAX_ANNOTATIONS_IN_PROMPT = 25;
+    private static final int MAX_NOTE_CHARS = 200;
+
+    private final ChartDrawingAnnotationRepository drawingRepo;
+    private final SymbolThesisRepository thesisRepo;
+
+    @Transactional(readOnly = true)
+    public AnnotationBundleDto buildForLevels(Long userId, String symbol, String tabUuid) {
+        if (userId == null || symbol == null) return AnnotationBundleDto.builder().annotations(Collections.emptyList()).build();
+        if (tabUuid == null || tabUuid.isBlank()) {
+            return buildForPattern(userId, symbol);
+        }
+        List<ChartDrawingAnnotation> rows = drawingRepo
+                .findByUserIdAndTabUuidAndSymbolAndActiveTrueOrderByWeightDescUpdatedAtDesc(userId, tabUuid, symbol);
+        SymbolThesis thesis = thesisRepo.findByUserIdAndTabUuidAndSymbol(userId, tabUuid, symbol).orElse(null);
+        return assemble(rows, thesis);
+    }
+
+    @Transactional(readOnly = true)
+    public AnnotationBundleDto buildForPattern(Long userId, String symbol) {
+        if (userId == null || symbol == null) return AnnotationBundleDto.builder().annotations(Collections.emptyList()).build();
+        List<ChartDrawingAnnotation> rows = drawingRepo
+                .findByUserIdAndSymbolAndActiveTrueOrderByWeightDescUpdatedAtDesc(userId, symbol);
+        SymbolThesis thesis = thesisRepo.findFirstByUserIdAndSymbolOrderByUpdatedAtDesc(userId, symbol).orElse(null);
+        return assemble(rows, thesis);
+    }
+
+    private AnnotationBundleDto assemble(List<ChartDrawingAnnotation> rows, SymbolThesis thesis) {
+        List<DrawingAnnotationDto> dtos = rows.stream().map(this::toDto).toList();
+        SymbolThesisDto thesisDto = thesis == null ? null : SymbolThesisDto.builder()
+                .id(thesis.getId())
+                .tabUuid(thesis.getTabUuid())
+                .symbol(thesis.getSymbol())
+                .bias(thesis.getBias())
+                .regime(thesis.getRegime())
+                .horizonDays(thesis.getHorizonDays())
+                .thesisText(thesis.getThesisText())
+                .updatedAt(thesis.getUpdatedAt())
+                .build();
+        return AnnotationBundleDto.builder().thesis(thesisDto).annotations(dtos).build();
+    }
+
+    /**
+     * Renders the bundle to a Markdown prompt section. Returns an empty string when the bundle is empty so
+     * callers can unconditionally append the result.
+     */
+    public String toPromptSection(AnnotationBundleDto bundle) {
+        if (bundle == null || bundle.isEmpty()) return "";
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("## Trader's Annotations\n\n");
+        sb.append("The trader has marked the following on this chart. Treat these as high-prior signals — ")
+                .append("they reflect setups and levels the trader believes matter. Use them to weigh trade ideas; ")
+                .append("when a trade idea aligns with an annotation, increase its confidence and reference the annotation ")
+                .append("in the rationale. When you propose a trade that ignores an annotation, justify why.\n\n");
+
+        SymbolThesisDto t = bundle.getThesis();
+        if (t != null) {
+            boolean has = (t.getThesisText() != null && !t.getThesisText().isBlank())
+                    || t.getBias() != null || t.getRegime() != null || t.getHorizonDays() != null;
+            if (has) {
+                sb.append("### Symbol thesis\n");
+                if (t.getBias() != null) sb.append("- Bias: ").append(t.getBias()).append("\n");
+                if (t.getRegime() != null) sb.append("- Regime: ").append(t.getRegime()).append("\n");
+                if (t.getHorizonDays() != null) sb.append("- Horizon (days): ").append(t.getHorizonDays()).append("\n");
+                if (t.getThesisText() != null && !t.getThesisText().isBlank()) {
+                    sb.append("- Trader's view: ").append(t.getThesisText().trim()).append("\n");
+                }
+                sb.append("\n");
+            }
+        }
+
+        List<DrawingAnnotationDto> anns = bundle.getAnnotations();
+        if (anns != null && !anns.isEmpty()) {
+            sb.append("### Drawn annotations (in priority order, weight 1-5)\n");
+            int n = Math.min(anns.size(), MAX_ANNOTATIONS_IN_PROMPT);
+            for (int i = 0; i < n; i++) {
+                DrawingAnnotationDto a = anns.get(i);
+                sb.append(i + 1).append(". [").append(a.getIntent())
+                        .append(" · weight ").append(a.getWeight() != null ? a.getWeight() : 3).append("]");
+                if (a.getInterval() != null) sb.append(" (").append(a.getInterval()).append(")");
+                sb.append("\n");
+                if (a.getIntentParamsJson() != null && !a.getIntentParamsJson().isBlank()) {
+                    sb.append("   Params: ").append(a.getIntentParamsJson().trim()).append("\n");
+                }
+                if (a.getGeometryJson() != null && !a.getGeometryJson().isBlank()) {
+                    sb.append("   Geometry: ").append(a.getGeometryJson().trim()).append("\n");
+                }
+                if (a.getNote() != null && !a.getNote().isBlank()) {
+                    String note = a.getNote().trim();
+                    if (note.length() > MAX_NOTE_CHARS) note = note.substring(0, MAX_NOTE_CHARS) + "…";
+                    sb.append("   Note: \"").append(note).append("\"\n");
+                }
+            }
+            if (anns.size() > MAX_ANNOTATIONS_IN_PROMPT) {
+                sb.append("(…").append(anns.size() - MAX_ANNOTATIONS_IN_PROMPT)
+                        .append(" lower-weight annotations omitted)\n");
+            }
+            sb.append("\n");
+        }
+
+        sb.append("### How to act on these annotations\n");
+        sb.append("- KEY_LEVEL / INVALIDATION / TARGET → use as anchors when computing entry/stop/target.\n");
+        sb.append("- RETEST_ENTRY → if price is approaching the level within the tolerance, propose a trade keyed on reversal confirmation at the level.\n");
+        sb.append("- BREAKOUT_CONFIRM → wait for `confirmation_bars` bars beyond the level before calling breakout.\n");
+        sb.append("- REJECT_ON_TOUCH → propose a fade trade at first touch.\n");
+        sb.append("- OVERTHROW_WATCH → do NOT enter on the immediate breakout. Wait for price to re-enter the pattern within `expected_settle_bars`; enter only on settle.\n");
+        sb.append("- ABC_PROJECTION → the listed ratios are valid C-leg completion targets. Highlight which target current price action favors.\n");
+        sb.append("- Free-text note → the trader's intent. Read literally and respect it.\n\n");
+
+        return sb.toString();
+    }
+
+    private DrawingAnnotationDto toDto(ChartDrawingAnnotation e) {
+        return DrawingAnnotationDto.builder()
+                .id(e.getId())
+                .tabUuid(e.getTabUuid())
+                .symbol(e.getSymbol())
+                .interval(e.getInterval())
+                .drawingId(e.getDrawingId())
+                .intent(e.getIntent())
+                .intentParamsJson(e.getIntentParamsJson())
+                .geometryJson(e.getGeometryJson())
+                .note(e.getNote())
+                .weight(e.getWeight())
+                .active(e.isActive())
+                .createdAt(e.getCreatedAt())
+                .updatedAt(e.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dtech/aitrader/annotation/service/AnnotationService.java
+++ b/src/main/java/com/dtech/aitrader/annotation/service/AnnotationService.java
@@ -1,0 +1,152 @@
+package com.dtech.aitrader.annotation.service;
+
+import com.dtech.aitrader.annotation.dto.DrawingAnnotationDto;
+import com.dtech.aitrader.annotation.dto.SaveAnnotationRequest;
+import com.dtech.aitrader.annotation.dto.SaveThesisRequest;
+import com.dtech.aitrader.annotation.dto.SymbolThesisDto;
+import com.dtech.aitrader.annotation.entity.ChartDrawingAnnotation;
+import com.dtech.aitrader.annotation.entity.SymbolThesis;
+import com.dtech.aitrader.annotation.repository.ChartDrawingAnnotationRepository;
+import com.dtech.aitrader.annotation.repository.SymbolThesisRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AnnotationService {
+
+    private final ChartDrawingAnnotationRepository drawingRepo;
+    private final SymbolThesisRepository thesisRepo;
+
+    @Transactional(readOnly = true)
+    public List<DrawingAnnotationDto> listForChart(Long userId, String symbol, String tabUuid) {
+        return drawingRepo
+                .findByUserIdAndTabUuidAndSymbolAndActiveTrueOrderByWeightDescUpdatedAtDesc(userId, tabUuid, symbol)
+                .stream().map(this::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<DrawingAnnotationDto> listForSymbol(Long userId, String symbol) {
+        return drawingRepo
+                .findByUserIdAndSymbolAndActiveTrueOrderByWeightDescUpdatedAtDesc(userId, symbol)
+                .stream().map(this::toDto).toList();
+    }
+
+    @Transactional
+    public DrawingAnnotationDto saveAnnotation(Long userId, SaveAnnotationRequest req) {
+        if (req.getTabUuid() == null || req.getTabUuid().isBlank()) {
+            throw new IllegalArgumentException("tabUuid required");
+        }
+        if (req.getSymbol() == null || req.getSymbol().isBlank()) {
+            throw new IllegalArgumentException("symbol required");
+        }
+        if (req.getIntent() == null || req.getIntent().isBlank()) {
+            throw new IllegalArgumentException("intent required");
+        }
+        String drawingId = (req.getDrawingId() == null || req.getDrawingId().isBlank())
+                ? "client-" + UUID.randomUUID()
+                : req.getDrawingId();
+
+        ChartDrawingAnnotation existing = drawingRepo
+                .findByUserIdAndTabUuidAndSymbolAndDrawingId(userId, req.getTabUuid(), req.getSymbol(), drawingId)
+                .orElse(null);
+
+        ChartDrawingAnnotation entity = existing != null ? existing : ChartDrawingAnnotation.builder()
+                .userId(userId)
+                .tabUuid(req.getTabUuid())
+                .symbol(req.getSymbol())
+                .drawingId(drawingId)
+                .active(true)
+                .build();
+        entity.setInterval(req.getInterval());
+        entity.setIntent(req.getIntent());
+        entity.setIntentParamsJson(req.getIntentParamsJson());
+        entity.setGeometryJson(req.getGeometryJson());
+        entity.setNote(req.getNote());
+        if (req.getWeight() != null) {
+            entity.setWeight(Math.max(1, Math.min(5, req.getWeight())));
+        } else if (entity.getWeight() == null) {
+            entity.setWeight(3);
+        }
+
+        return toDto(drawingRepo.save(entity));
+    }
+
+    @Transactional
+    public void deleteAnnotation(Long userId, Long annotationId) {
+        ChartDrawingAnnotation row = drawingRepo.findById(annotationId)
+                .orElseThrow(() -> new IllegalArgumentException("annotation not found: " + annotationId));
+        if (!row.getUserId().equals(userId)) {
+            throw new SecurityException("annotation belongs to another user");
+        }
+        drawingRepo.delete(row);
+    }
+
+    @Transactional(readOnly = true)
+    public SymbolThesisDto getThesis(Long userId, String symbol, String tabUuid) {
+        return thesisRepo.findByUserIdAndTabUuidAndSymbol(userId, tabUuid, symbol)
+                .map(this::toDto)
+                .orElse(null);
+    }
+
+    @Transactional
+    public SymbolThesisDto saveThesis(Long userId, SaveThesisRequest req) {
+        if (req.getTabUuid() == null || req.getTabUuid().isBlank()) {
+            throw new IllegalArgumentException("tabUuid required");
+        }
+        if (req.getSymbol() == null || req.getSymbol().isBlank()) {
+            throw new IllegalArgumentException("symbol required");
+        }
+
+        SymbolThesis entity = thesisRepo
+                .findByUserIdAndTabUuidAndSymbol(userId, req.getTabUuid(), req.getSymbol())
+                .orElse(SymbolThesis.builder()
+                        .userId(userId)
+                        .tabUuid(req.getTabUuid())
+                        .symbol(req.getSymbol())
+                        .build());
+        entity.setBias(req.getBias());
+        entity.setRegime(req.getRegime());
+        entity.setHorizonDays(req.getHorizonDays());
+        entity.setThesisText(req.getThesisText());
+
+        return toDto(thesisRepo.save(entity));
+    }
+
+    private DrawingAnnotationDto toDto(ChartDrawingAnnotation e) {
+        return DrawingAnnotationDto.builder()
+                .id(e.getId())
+                .tabUuid(e.getTabUuid())
+                .symbol(e.getSymbol())
+                .interval(e.getInterval())
+                .drawingId(e.getDrawingId())
+                .intent(e.getIntent())
+                .intentParamsJson(e.getIntentParamsJson())
+                .geometryJson(e.getGeometryJson())
+                .note(e.getNote())
+                .weight(e.getWeight())
+                .active(e.isActive())
+                .createdAt(e.getCreatedAt())
+                .updatedAt(e.getUpdatedAt())
+                .build();
+    }
+
+    private SymbolThesisDto toDto(SymbolThesis e) {
+        return SymbolThesisDto.builder()
+                .id(e.getId())
+                .tabUuid(e.getTabUuid())
+                .symbol(e.getSymbol())
+                .bias(e.getBias())
+                .regime(e.getRegime())
+                .horizonDays(e.getHorizonDays())
+                .thesisText(e.getThesisText())
+                .updatedAt(e.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/dtech/aitrader/annotation/web/DrawingAnnotationController.java
+++ b/src/main/java/com/dtech/aitrader/annotation/web/DrawingAnnotationController.java
@@ -1,0 +1,98 @@
+package com.dtech.aitrader.annotation.web;
+
+import com.dtech.aitrader.annotation.dto.AnnotationBundleDto;
+import com.dtech.aitrader.annotation.dto.DrawingAnnotationDto;
+import com.dtech.aitrader.annotation.dto.SaveAnnotationRequest;
+import com.dtech.aitrader.annotation.dto.SaveThesisRequest;
+import com.dtech.aitrader.annotation.dto.SymbolThesisDto;
+import com.dtech.aitrader.annotation.service.AnnotationBundleBuilder;
+import com.dtech.aitrader.annotation.service.AnnotationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/ai-trader/annotations")
+@RequiredArgsConstructor
+@Slf4j
+public class DrawingAnnotationController {
+
+    private final AnnotationService service;
+    private final AnnotationBundleBuilder bundleBuilder;
+
+    @GetMapping
+    public ResponseEntity<List<DrawingAnnotationDto>> list(
+            @RequestParam String symbol,
+            @RequestParam(required = false) String tabUuid,
+            Authentication auth) {
+        Long userId = extractUserId(auth);
+        List<DrawingAnnotationDto> result = (tabUuid == null || tabUuid.isBlank())
+                ? service.listForSymbol(userId, symbol)
+                : service.listForChart(userId, symbol, tabUuid);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/bundle")
+    public ResponseEntity<AnnotationBundleDto> bundle(
+            @RequestParam String symbol,
+            @RequestParam(required = false) String tabUuid,
+            Authentication auth) {
+        Long userId = extractUserId(auth);
+        AnnotationBundleDto b = (tabUuid == null || tabUuid.isBlank())
+                ? bundleBuilder.buildForPattern(userId, symbol)
+                : bundleBuilder.buildForLevels(userId, symbol, tabUuid);
+        return ResponseEntity.ok(b);
+    }
+
+    @PostMapping
+    public ResponseEntity<DrawingAnnotationDto> save(
+            @RequestBody SaveAnnotationRequest req,
+            Authentication auth) {
+        Long userId = extractUserId(auth);
+        return ResponseEntity.ok(service.saveAnnotation(userId, req));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> delete(@PathVariable Long id, Authentication auth) {
+        Long userId = extractUserId(auth);
+        try {
+            service.deleteAnnotation(userId, id);
+            return ResponseEntity.ok(Map.of("status", "deleted"));
+        } catch (SecurityException se) {
+            return ResponseEntity.status(403).body(Map.of("error", "forbidden"));
+        } catch (IllegalArgumentException iae) {
+            return ResponseEntity.status(404).body(Map.of("error", "not found"));
+        }
+    }
+
+    @GetMapping("/thesis")
+    public ResponseEntity<SymbolThesisDto> getThesis(
+            @RequestParam String symbol,
+            @RequestParam String tabUuid,
+            Authentication auth) {
+        Long userId = extractUserId(auth);
+        SymbolThesisDto t = service.getThesis(userId, symbol, tabUuid);
+        return t == null ? ResponseEntity.noContent().build() : ResponseEntity.ok(t);
+    }
+
+    @PutMapping("/thesis")
+    public ResponseEntity<SymbolThesisDto> saveThesis(
+            @RequestBody SaveThesisRequest req,
+            Authentication auth) {
+        Long userId = extractUserId(auth);
+        return ResponseEntity.ok(service.saveThesis(userId, req));
+    }
+
+    private Long extractUserId(Authentication auth) {
+        if (auth == null || auth.getName() == null) {
+            throw new IllegalStateException("User not authenticated");
+        }
+        // Matches the pattern used by AiLevelsController until UserRepository integration lands.
+        return 1L;
+    }
+}

--- a/src/main/java/com/dtech/aitrader/service/AiLevelsPromptBuilder.java
+++ b/src/main/java/com/dtech/aitrader/service/AiLevelsPromptBuilder.java
@@ -32,17 +32,30 @@ public class AiLevelsPromptBuilder {
      * @return Levels prompt using latest data
      */
     public String buildLevelsPrompt(String symbol) {
-        return buildLevelsPrompt(symbol, Optional.empty());
+        return buildLevelsPrompt(symbol, Optional.empty(), "");
     }
 
     /**
      * Builds levels prompt sliced to a specific asOf instant (no look-ahead).
-     * @param symbol The symbol to analyze
-     * @param asOf If present, slice all bars to bar.endTime <= asOf
-     * @return Levels prompt with data as-of the specified instant
+     * Delegates to the annotation-aware overload with no annotations.
      */
     public String buildLevelsPrompt(String symbol, Optional<Instant> asOf) {
-        log.info("Building levels prompt for symbol: {} asOf: {}", symbol, asOf);
+        return buildLevelsPrompt(symbol, asOf, "");
+    }
+
+    /**
+     * Builds levels prompt sliced to a specific asOf instant, with an optional pre-rendered annotations
+     * section. The annotations fragment is injected immediately after the as-of timestamp block so the
+     * agent sees the trader's intent before the indicator/bar dump.
+     *
+     * @param symbol The symbol to analyze
+     * @param asOf If present, slice all bars to bar.endTime &lt;= asOf
+     * @param annotationsPromptFragment Pre-rendered Markdown annotations section, or empty/null for none
+     * @return Levels prompt with data as-of the specified instant
+     */
+    public String buildLevelsPrompt(String symbol, Optional<Instant> asOf, String annotationsPromptFragment) {
+        log.info("Building levels prompt for symbol: {} asOf: {} hasAnnotations: {}",
+                symbol, asOf, annotationsPromptFragment != null && !annotationsPromptFragment.isBlank());
 
         try {
             // Fetch hourly, daily, and weekly bars
@@ -112,6 +125,12 @@ public class AiLevelsPromptBuilder {
             // As-of timestamp
             prompt.append("## As-of timestamp\n");
             prompt.append(latestIso).append("\n\n");
+
+            // Trader's annotations — placed up front so the agent reads intent before the data dump
+            if (annotationsPromptFragment != null && !annotationsPromptFragment.isBlank()) {
+                prompt.append(annotationsPromptFragment);
+                if (!annotationsPromptFragment.endsWith("\n\n")) prompt.append("\n");
+            }
 
             // Weekly bars
             prompt.append("## Weekly bars (last ").append(weeklyBars.size()).append(" weeks)\n");

--- a/src/main/java/com/dtech/aitrader/service/LevelsAgentService.java
+++ b/src/main/java/com/dtech/aitrader/service/LevelsAgentService.java
@@ -1,5 +1,7 @@
 package com.dtech.aitrader.service;
 
+import com.dtech.aitrader.annotation.dto.AnnotationBundleDto;
+import com.dtech.aitrader.annotation.service.AnnotationBundleBuilder;
 import com.dtech.aitrader.data.AiLevels;
 import com.dtech.aitrader.data.AiTraderSymbol;
 import com.dtech.aitrader.repository.AiLevelsRepository;
@@ -27,6 +29,7 @@ public class LevelsAgentService {
     private final AiLevelsRepository aiLevelsRepository;
     private final AiTraderSymbolRepository aiTraderSymbolRepository;
     private final ObjectMapper objectMapper;
+    private final AnnotationBundleBuilder annotationBundleBuilder;
 
     private static final String SYSTEM_PROMPT = """
 You are a senior chart analyst specializing in structural levels on Indian FNO equities.
@@ -60,25 +63,40 @@ Use ISO-8601 UTC timestamps with the trailing 'Z'. Use absolute INR prices.
      * Runs AI levels agent for a symbol (uses current time).
      */
     public AiLevels runForSymbol(String symbol, Long userId) {
-        return runForSymbol(symbol, userId, Optional.empty());
+        return runForSymbol(symbol, userId, Optional.empty(), null);
     }
 
     /**
-     * Runs AI levels agent for a symbol with optional asOf timestamp.
-     * @param symbol The symbol to analyze
-     * @param userId The user ID
-     * @param asOf If present, slice data to this instant; otherwise use current time
-     * @return Generated AiLevels record
+     * Runs AI levels agent for a symbol with optional asOf timestamp. Annotation lookup will fall back
+     * to the user's most-recent-thesis-and-cross-tab annotations since no tab context is provided.
      */
     public AiLevels runForSymbol(String symbol, Long userId, Optional<Instant> asOf) {
-        log.info("Running AI levels agent for symbol: {}, userId: {}, asOf: {}", symbol, userId, asOf);
+        return runForSymbol(symbol, userId, asOf, null);
+    }
+
+    /**
+     * Runs AI levels agent for a symbol with optional asOf and an optional tab uuid for tab-scoped annotations.
+     *
+     * @param symbol  The symbol to analyze
+     * @param userId  The user ID
+     * @param asOf    If present, slice data to this instant; otherwise use current time
+     * @param tabUuid If present, scope annotations + thesis lookup to this tab; otherwise look across all the user's tabs
+     * @return Generated AiLevels record
+     */
+    public AiLevels runForSymbol(String symbol, Long userId, Optional<Instant> asOf, String tabUuid) {
+        log.info("Running AI levels agent for symbol: {}, userId: {}, asOf: {}, tabUuid: {}",
+                symbol, userId, asOf, tabUuid);
 
         try {
             // Resolve user's active AI provider
             AiProviderResolver.ProviderConfig cfg = aiProviderResolver.resolveForUser(userId);
 
+            // Pull trader annotations + thesis; render to a Markdown fragment for the prompt
+            AnnotationBundleDto bundle = annotationBundleBuilder.buildForLevels(userId, symbol, tabUuid);
+            String annotationsFragment = annotationBundleBuilder.toPromptSection(bundle);
+
             // Build prompt (with asOf if provided)
-            String prompt = promptBuilderService.buildLevelsPrompt(symbol, asOf);
+            String prompt = promptBuilderService.buildLevelsPrompt(symbol, asOf, annotationsFragment);
 
             // Call LLM gateway
             LlmGateway.LlmResponse response = llmGateway.call(cfg, SYSTEM_PROMPT, prompt, 4096);

--- a/src/main/java/com/dtech/aitrader/service/PatternAgentPromptBuilder.java
+++ b/src/main/java/com/dtech/aitrader/service/PatternAgentPromptBuilder.java
@@ -52,17 +52,28 @@ public class PatternAgentPromptBuilder {
      * @return User prompt for Claude with complete decision context
      */
     public String buildPatternPrompt(PatternSignal signal) {
-        return buildPatternPrompt(signal, Optional.empty());
+        return buildPatternPrompt(signal, Optional.empty(), "");
     }
 
     /**
      * Builds a pattern prompt with optional asOf slicing for walk-forward testing.
-     *
-     * @param signal The pattern signal
-     * @param asOf If present, slice bars to bar.endTime <= asOf; use signal.signalTime if empty
-     * @return User prompt with no look-ahead
+     * Delegates to the annotation-aware overload with no annotations.
      */
     public String buildPatternPrompt(PatternSignal signal, Optional<Instant> asOf) {
+        return buildPatternPrompt(signal, asOf, "");
+    }
+
+    /**
+     * Builds a pattern prompt with an optional pre-rendered trader-annotations fragment. The fragment
+     * is injected after the PATTERN SIGNAL block so the agent reads the trader's intent before the
+     * indicator/bar dump.
+     *
+     * @param signal The pattern signal
+     * @param asOf If present, slice bars to bar.endTime &lt;= asOf; use signal.signalTime if empty
+     * @param annotationsPromptFragment Pre-rendered Markdown annotations section, or empty/null for none
+     * @return User prompt with no look-ahead
+     */
+    public String buildPatternPrompt(PatternSignal signal, Optional<Instant> asOf, String annotationsPromptFragment) {
         // If asOf not provided, use signal's signalTime
         Instant effectiveAsOf = asOf.orElse(signal.getSignalTime());
         StringBuilder prompt = new StringBuilder();
@@ -77,6 +88,12 @@ public class PatternAgentPromptBuilder {
             signal.getSuggestedEntry(), signal.getSuggestedSl(), signal.getSuggestedTarget()));
         prompt.append(String.format("Signal Time: %s\n", signal.getSignalTime()));
         prompt.append(String.format("Signal Ref: %s\n\n", signal.getSignalRef()));
+
+        // Trader's annotations — placed early so the agent reads intent before the data dump
+        if (annotationsPromptFragment != null && !annotationsPromptFragment.isBlank()) {
+            prompt.append(annotationsPromptFragment);
+            if (!annotationsPromptFragment.endsWith("\n\n")) prompt.append("\n");
+        }
 
         // 2. Extra context (engine-specific)
         if (signal.getExtraContext() != null && !signal.getExtraContext().isEmpty()) {

--- a/src/main/java/com/dtech/aitrader/service/PatternAgentService.java
+++ b/src/main/java/com/dtech/aitrader/service/PatternAgentService.java
@@ -1,5 +1,7 @@
 package com.dtech.aitrader.service;
 
+import com.dtech.aitrader.annotation.dto.AnnotationBundleDto;
+import com.dtech.aitrader.annotation.service.AnnotationBundleBuilder;
 import com.dtech.aitrader.data.AgentDecision;
 import com.dtech.aitrader.data.PaperTrade;
 import com.dtech.aitrader.model.PatternSignal;
@@ -30,6 +32,7 @@ public class PatternAgentService {
     private final AgentDecisionRepository agentDecisionRepository;
     private final PaperTradeRepository paperTradeRepository;
     private final ObjectMapper objectMapper;
+    private final AnnotationBundleBuilder annotationBundleBuilder;
 
     @Value("${pattern.model:claude-sonnet-4-5-20250929}")
     private String patternModel;
@@ -51,8 +54,12 @@ public class PatternAgentService {
         log.info("PatternAgent.decide: symbol={}, patternType={}, direction={}",
             signal.getSymbol(), signal.getPatternType(), signal.getDirection());
 
+        // Pull trader annotations + thesis for this user+symbol; render to prompt fragment
+        AnnotationBundleDto bundle = annotationBundleBuilder.buildForPattern(userId, signal.getSymbol());
+        String annotationsFragment = annotationBundleBuilder.toPromptSection(bundle);
+
         // Build prompt
-        String userPrompt = promptBuilder.buildPatternPrompt(signal);
+        String userPrompt = promptBuilder.buildPatternPrompt(signal, Optional.empty(), annotationsFragment);
 
         // Resolve provider config — the active provider's model is the source of truth
         AiProviderResolver.ProviderConfig cfg = providerResolver.resolveForUser(userId);

--- a/src/main/java/com/dtech/aitrader/web/AiLevelsController.java
+++ b/src/main/java/com/dtech/aitrader/web/AiLevelsController.java
@@ -43,8 +43,9 @@ public class AiLevelsController {
             // Extract user ID from authentication
             Long userId = extractUserId(auth);
 
-            // Run levels agent
-            AiLevels aiLevels = levelsAgentService.runForSymbol(request.getSymbol(), userId);
+            // Run levels agent (tabId is the tab uuid → annotation scoping)
+            AiLevels aiLevels = levelsAgentService.runForSymbol(
+                    request.getSymbol(), userId, java.util.Optional.empty(), request.getTabId());
 
             // Parse levels JSON
             JsonNode levelsJson = objectMapper.readTree(aiLevels.getLevelsJson());

--- a/ui/chart-draw-app/src/aitrader/AiTraderPage.tsx
+++ b/ui/chart-draw-app/src/aitrader/AiTraderPage.tsx
@@ -5,6 +5,7 @@ import ActiveTradesPanel from './ActiveTradesPanel';
 import WatchTradesPanel from './WatchTradesPanel';
 import SimulatedTradesPanel from './SimulatedTradesPanel';
 import WatchlistPanel from './WatchlistPanel';
+import AnnotationsPanel from './annotations/AnnotationsPanel';
 import { getApiUrl } from '../config/api';
 import { withAuth } from '../utils/apiHelper';
 import './AiTraderPage.css';
@@ -220,6 +221,9 @@ export default function AiTraderPage() {
         </CollapsibleSection>
         <CollapsibleSection title={`Simulated trades · ${selectedSymbol}`} defaultOpen={false}>
           <SimulatedTradesPanel symbol={selectedSymbol} onSelectSymbol={handleSelectSymbol} />
+        </CollapsibleSection>
+        <CollapsibleSection title={`Annotations & thesis · ${selectedSymbol}`} defaultOpen={true}>
+          <AnnotationsPanel symbol={selectedSymbol} tabUuid={tabId} interval="OneHour" />
         </CollapsibleSection>
       </div>
 

--- a/ui/chart-draw-app/src/aitrader/annotations/AnnotationFormModal.tsx
+++ b/ui/chart-draw-app/src/aitrader/annotations/AnnotationFormModal.tsx
@@ -1,0 +1,263 @@
+import { useEffect, useState } from 'react';
+import {
+  AnnotationIntent, DrawingAnnotation, INTENT_LABELS, INTENT_ORDER,
+} from './types';
+
+interface Props {
+  tabUuid: string;
+  symbol: string;
+  interval?: string;
+  initial?: DrawingAnnotation | null;   // null = new
+  onClose: () => void;
+  onSave: (payload: {
+    drawingId?: string;
+    intent: AnnotationIntent;
+    intentParamsJson?: string;
+    geometryJson?: string;
+    note?: string;
+    weight: number;
+  }) => Promise<void>;
+}
+
+type Params = Record<string, unknown>;
+
+function parseParams(raw?: string): Params {
+  if (!raw) return {};
+  try { return JSON.parse(raw); } catch { return {}; }
+}
+
+export default function AnnotationFormModal({
+  tabUuid: _tabUuid, symbol, interval: _interval, initial, onClose, onSave,
+}: Props) {
+  const [intent, setIntent] = useState<AnnotationIntent>(initial?.intent || 'KEY_LEVEL');
+  const [note, setNote] = useState<string>(initial?.note || '');
+  const [weight, setWeight] = useState<number>(initial?.weight ?? 3);
+  const [drawingId, setDrawingId] = useState<string>(initial?.drawingId || '');
+  const [geometry, setGeometry] = useState<string>(initial?.geometryJson || '');
+  const [params, setParams] = useState<Params>(parseParams(initial?.intentParamsJson));
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Reset params to sensible defaults when intent changes (only for new annotations)
+    if (initial) return;
+    if (intent === 'ABC_PROJECTION') setParams({ ratios: [1.0, 1.272, 1.618] });
+    else if (intent === 'RETEST_ENTRY') setParams({ tolerance_pct: 0.5, side: 'either' });
+    else if (intent === 'BREAKOUT_CONFIRM') setParams({ confirmation_bars: 2, side: 'above' });
+    else if (intent === 'OVERTHROW_WATCH') setParams({ max_overthrow_pct: 1.5, expected_settle_bars: 6 });
+    else if (intent === 'REJECT_ON_TOUCH') setParams({ tolerance_pct: 0.3 });
+    else if (intent === 'INVALIDATION' || intent === 'TARGET') setParams({ side: 'above' });
+    else setParams({});
+  }, [intent, initial]);
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave({
+        drawingId: drawingId || undefined,
+        intent,
+        intentParamsJson: Object.keys(params).length ? JSON.stringify(params) : undefined,
+        geometryJson: geometry || undefined,
+        note: note || undefined,
+        weight,
+      });
+      onClose();
+    } catch (e: any) {
+      setError(e?.message || 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function updateParam(key: string, value: unknown) {
+    setParams(p => ({ ...p, [key]: value }));
+  }
+
+  return (
+    <div style={overlay} onClick={onClose}>
+      <div style={modal} onClick={e => e.stopPropagation()}>
+        <div style={header}>
+          <h3 style={{ margin: 0, fontSize: 15 }}>
+            {initial ? 'Edit annotation' : 'New annotation'} · {symbol}
+          </h3>
+          <button onClick={onClose} style={iconBtn}>✕</button>
+        </div>
+
+        <div style={body}>
+          {error && <div style={errorBox}>{error}</div>}
+
+          <Field label="Intent">
+            <select value={intent} onChange={e => setIntent(e.target.value as AnnotationIntent)} style={input}>
+              {INTENT_ORDER.map(i => <option key={i} value={i}>{INTENT_LABELS[i]}</option>)}
+            </select>
+          </Field>
+
+          <Field label="Drawing ID (auto-generated if blank)">
+            <input
+              value={drawingId}
+              onChange={e => setDrawingId(e.target.value)}
+              placeholder="e.g. tv-shape-1234 or blank"
+              style={input}
+            />
+          </Field>
+
+          {/* Intent-specific param fields */}
+          {intent === 'RETEST_ENTRY' && (
+            <>
+              <Field label="Tolerance %">
+                <input type="number" step="0.1" value={String(params.tolerance_pct ?? '')}
+                  onChange={e => updateParam('tolerance_pct', Number(e.target.value))} style={input} />
+              </Field>
+              <Field label="Side">
+                <select value={String(params.side ?? 'either')} onChange={e => updateParam('side', e.target.value)} style={input}>
+                  <option value="above">above</option>
+                  <option value="below">below</option>
+                  <option value="either">either</option>
+                </select>
+              </Field>
+            </>
+          )}
+
+          {intent === 'BREAKOUT_CONFIRM' && (
+            <>
+              <Field label="Confirmation bars">
+                <input type="number" min="1" value={String(params.confirmation_bars ?? '')}
+                  onChange={e => updateParam('confirmation_bars', Number(e.target.value))} style={input} />
+              </Field>
+              <Field label="Side">
+                <select value={String(params.side ?? 'above')} onChange={e => updateParam('side', e.target.value)} style={input}>
+                  <option value="above">above</option>
+                  <option value="below">below</option>
+                </select>
+              </Field>
+            </>
+          )}
+
+          {intent === 'OVERTHROW_WATCH' && (
+            <>
+              <Field label="Max overthrow %">
+                <input type="number" step="0.1" value={String(params.max_overthrow_pct ?? '')}
+                  onChange={e => updateParam('max_overthrow_pct', Number(e.target.value))} style={input} />
+              </Field>
+              <Field label="Expected settle bars">
+                <input type="number" min="1" value={String(params.expected_settle_bars ?? '')}
+                  onChange={e => updateParam('expected_settle_bars', Number(e.target.value))} style={input} />
+              </Field>
+            </>
+          )}
+
+          {intent === 'ABC_PROJECTION' && (
+            <Field label="C-leg ratios (comma-separated)">
+              <input
+                value={Array.isArray(params.ratios) ? (params.ratios as number[]).join(', ') : '1.0, 1.272, 1.618'}
+                onChange={e => {
+                  const arr = e.target.value.split(',').map(s => Number(s.trim())).filter(n => Number.isFinite(n));
+                  updateParam('ratios', arr);
+                }}
+                placeholder="1.0, 1.272, 1.618"
+                style={input}
+              />
+            </Field>
+          )}
+
+          {intent === 'REJECT_ON_TOUCH' && (
+            <Field label="Tolerance %">
+              <input type="number" step="0.1" value={String(params.tolerance_pct ?? '')}
+                onChange={e => updateParam('tolerance_pct', Number(e.target.value))} style={input} />
+            </Field>
+          )}
+
+          {(intent === 'INVALIDATION' || intent === 'TARGET') && (
+            <Field label="Side">
+              <select value={String(params.side ?? 'above')} onChange={e => updateParam('side', e.target.value)} style={input}>
+                <option value="above">above</option>
+                <option value="below">below</option>
+              </select>
+            </Field>
+          )}
+
+          <Field label="Geometry JSON (optional — describe what you drew)">
+            <textarea
+              value={geometry}
+              onChange={e => setGeometry(e.target.value)}
+              rows={3}
+              placeholder='e.g. {"type":"trendline","points":[{"t":"2026-04-12T00:00:00Z","p":1532.4},{"t":"2026-05-08T00:00:00Z","p":1611.2}]}'
+              style={{ ...input, fontFamily: 'monospace', fontSize: 11, resize: 'vertical' }}
+            />
+          </Field>
+
+          <Field label="Note (the AI reads this)">
+            <textarea
+              value={note}
+              onChange={e => setNote(e.target.value)}
+              rows={3}
+              maxLength={1000}
+              placeholder="e.g. Strong rising support, look for clean retest with reversal candle"
+              style={{ ...input, resize: 'vertical' }}
+            />
+          </Field>
+
+          <Field label={`Weight (importance): ${weight}`}>
+            <input type="range" min="1" max="5" value={weight}
+              onChange={e => setWeight(Number(e.target.value))}
+              style={{ width: '100%' }} />
+          </Field>
+        </div>
+
+        <div style={footer}>
+          <button onClick={onClose} style={btnGray}>Cancel</button>
+          <button onClick={handleSave} disabled={saving} style={saving ? btnGray : btnPrimary}>
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ marginBottom: 10 }}>
+      <div style={{ fontSize: 11, color: '#666', marginBottom: 3 }}>{label}</div>
+      {children}
+    </div>
+  );
+}
+
+const overlay: React.CSSProperties = {
+  position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.5)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 10000,
+};
+const modal: React.CSSProperties = {
+  background: '#fff', borderRadius: 6, width: 460, maxHeight: '90vh',
+  display: 'flex', flexDirection: 'column', boxShadow: '0 8px 24px rgba(0,0,0,0.2)',
+};
+const header: React.CSSProperties = {
+  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+  padding: '10px 14px', borderBottom: '1px solid #e0e0e0',
+};
+const body: React.CSSProperties = { padding: '12px 14px', overflowY: 'auto' };
+const footer: React.CSSProperties = {
+  display: 'flex', justifyContent: 'flex-end', gap: 8,
+  padding: '10px 14px', borderTop: '1px solid #e0e0e0',
+};
+const input: React.CSSProperties = {
+  width: '100%', padding: '6px 8px', fontSize: 13,
+  border: '1px solid #ccc', borderRadius: 4, boxSizing: 'border-box',
+};
+const iconBtn: React.CSSProperties = {
+  background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 16, color: '#666',
+};
+const btnPrimary: React.CSSProperties = {
+  background: '#1565c0', color: '#fff', border: 'none', borderRadius: 4,
+  padding: '6px 16px', cursor: 'pointer', fontSize: 13, fontWeight: 600,
+};
+const btnGray: React.CSSProperties = {
+  background: '#999', color: '#fff', border: 'none', borderRadius: 4,
+  padding: '6px 16px', cursor: 'pointer', fontSize: 13,
+};
+const errorBox: React.CSSProperties = {
+  background: '#fde7e7', border: '1px solid #ef5350', borderRadius: 4,
+  padding: '6px 10px', color: '#c62828', fontSize: 12, marginBottom: 8,
+};

--- a/ui/chart-draw-app/src/aitrader/annotations/AnnotationsPanel.tsx
+++ b/ui/chart-draw-app/src/aitrader/annotations/AnnotationsPanel.tsx
@@ -1,0 +1,233 @@
+import { useCallback, useEffect, useState } from 'react';
+import AnnotationFormModal from './AnnotationFormModal';
+import {
+  deleteAnnotation, getThesis, listAnnotations, saveAnnotation, saveThesis,
+} from './api';
+import {
+  AnnotationIntent, DrawingAnnotation, INTENT_LABELS, SymbolThesis,
+} from './types';
+
+interface Props {
+  symbol: string;
+  tabUuid: string;
+  interval?: string;
+}
+
+export default function AnnotationsPanel({ symbol, tabUuid, interval }: Props) {
+  const [annotations, setAnnotations] = useState<DrawingAnnotation[]>([]);
+  const [thesis, setThesis] = useState<SymbolThesis | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [editTarget, setEditTarget] = useState<DrawingAnnotation | null>(null);
+
+  // Editable thesis state
+  const [thesisDirty, setThesisDirty] = useState(false);
+  const [bias, setBias] = useState<string>('');
+  const [regime, setRegime] = useState<string>('');
+  const [thesisText, setThesisText] = useState<string>('');
+  const [thesisSaving, setThesisSaving] = useState(false);
+  const [thesisError, setThesisError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    if (!symbol || !tabUuid) return;
+    setLoading(true);
+    try {
+      const [ann, t] = await Promise.all([
+        listAnnotations(symbol, tabUuid),
+        getThesis(symbol, tabUuid),
+      ]);
+      setAnnotations(ann);
+      setThesis(t);
+      setBias(t?.bias || '');
+      setRegime(t?.regime || '');
+      setThesisText(t?.thesisText || '');
+      setThesisDirty(false);
+    } catch (e: any) {
+      console.warn('annotations load failed', e);
+    } finally {
+      setLoading(false);
+    }
+  }, [symbol, tabUuid]);
+
+  useEffect(() => { load(); }, [load]);
+
+  async function handleSaveThesis() {
+    setThesisSaving(true);
+    setThesisError(null);
+    try {
+      const saved = await saveThesis({
+        tabUuid, symbol,
+        bias: bias || undefined,
+        regime: regime || undefined,
+        thesisText: thesisText || undefined,
+      });
+      setThesis(saved);
+      setThesisDirty(false);
+    } catch (e: any) {
+      setThesisError(e?.message || 'Save failed');
+    } finally {
+      setThesisSaving(false);
+    }
+  }
+
+  async function handleSaveAnnotation(payload: {
+    drawingId?: string;
+    intent: AnnotationIntent;
+    intentParamsJson?: string;
+    geometryJson?: string;
+    note?: string;
+    weight: number;
+  }) {
+    await saveAnnotation({
+      tabUuid, symbol, interval,
+      ...payload,
+    });
+    await load();
+  }
+
+  async function handleDelete(id: number) {
+    if (!confirm('Delete this annotation? The AI will no longer see it.')) return;
+    try {
+      await deleteAnnotation(id);
+      await load();
+    } catch (e: any) {
+      alert('Delete failed: ' + (e?.message || 'unknown error'));
+    }
+  }
+
+  return (
+    <div style={{ padding: '8px 10px', fontSize: 13 }}>
+      {/* Thesis editor */}
+      <div style={{ border: '1px solid #e0e0e0', borderRadius: 4, padding: 8, marginBottom: 10 }}>
+        <div style={{ fontSize: 11, color: '#666', marginBottom: 4 }}>Symbol thesis</div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 6, marginBottom: 6 }}>
+          <select value={bias} onChange={e => { setBias(e.target.value); setThesisDirty(true); }} style={selectStyle}>
+            <option value="">— bias —</option>
+            <option value="LONG">LONG</option>
+            <option value="SHORT">SHORT</option>
+            <option value="NEUTRAL">NEUTRAL</option>
+            <option value="RANGE">RANGE</option>
+          </select>
+          <input value={regime} onChange={e => { setRegime(e.target.value); setThesisDirty(true); }}
+            placeholder="regime (e.g. trending)" style={selectStyle} />
+        </div>
+        <textarea
+          value={thesisText}
+          onChange={e => { setThesisText(e.target.value); setThesisDirty(true); }}
+          placeholder="Your overall view on this symbol (read by AI)"
+          rows={3}
+          style={{ ...selectStyle, resize: 'vertical', width: '100%', boxSizing: 'border-box' }}
+        />
+        {thesisError && <div style={{ fontSize: 11, color: '#c62828', marginTop: 4 }}>{thesisError}</div>}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 6 }}>
+          <span style={{ fontSize: 10, color: '#999' }}>
+            {thesis?.updatedAt ? `Updated ${new Date(thesis.updatedAt).toLocaleString()}` : 'Not yet saved'}
+          </span>
+          <button
+            onClick={handleSaveThesis}
+            disabled={!thesisDirty || thesisSaving}
+            style={(!thesisDirty || thesisSaving) ? btnGrayMini : btnPrimaryMini}
+          >
+            {thesisSaving ? 'Saving…' : 'Save thesis'}
+          </button>
+        </div>
+      </div>
+
+      {/* Annotations list header */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 6 }}>
+        <span style={{ fontSize: 11, color: '#666', textTransform: 'uppercase', letterSpacing: 0.4 }}>
+          Annotations · {annotations.length}
+        </span>
+        <button onClick={() => { setEditTarget(null); setShowModal(true); }} style={btnPrimaryMini}>+ Add</button>
+      </div>
+
+      {loading && <div style={{ color: '#999', padding: '8px 0' }}>Loading…</div>}
+      {!loading && annotations.length === 0 && (
+        <div style={{ color: '#999', fontSize: 12, padding: '8px 0' }}>
+          No annotations yet. Click <b>+ Add</b> to attach intent + a note to a drawing.
+        </div>
+      )}
+
+      {!loading && annotations.map(a => (
+        <div key={a.id} style={annCard}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 6 }}>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 2 }}>
+                <span style={intentBadge(a.intent)}>{a.intent.replace(/_/g, ' ')}</span>
+                <span style={{ fontSize: 10, color: '#888' }}>★{a.weight}</span>
+              </div>
+              {a.note && (
+                <div style={{ fontSize: 12, color: '#222', whiteSpace: 'pre-wrap' }}>
+                  {a.note}
+                </div>
+              )}
+              {a.intentParamsJson && (
+                <div style={{ fontFamily: 'monospace', fontSize: 10, color: '#666', marginTop: 2 }}>
+                  {a.intentParamsJson}
+                </div>
+              )}
+              {a.drawingId && (
+                <div style={{ fontSize: 10, color: '#aaa', marginTop: 2 }}>id: {a.drawingId}</div>
+              )}
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+              <button onClick={() => { setEditTarget(a); setShowModal(true); }} style={btnLink}>edit</button>
+              <button onClick={() => handleDelete(a.id)} style={btnLinkDanger}>delete</button>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      {showModal && (
+        <AnnotationFormModal
+          tabUuid={tabUuid}
+          symbol={symbol}
+          interval={interval}
+          initial={editTarget}
+          onClose={() => { setShowModal(false); setEditTarget(null); }}
+          onSave={handleSaveAnnotation}
+        />
+      )}
+    </div>
+  );
+}
+
+const selectStyle: React.CSSProperties = {
+  fontSize: 12, padding: '4px 6px', border: '1px solid #ccc',
+  borderRadius: 3, background: '#fff',
+};
+const btnPrimaryMini: React.CSSProperties = {
+  background: '#1565c0', color: '#fff', border: 'none', borderRadius: 3,
+  padding: '3px 10px', fontSize: 11, fontWeight: 600, cursor: 'pointer',
+};
+const btnGrayMini: React.CSSProperties = {
+  background: '#bbb', color: '#fff', border: 'none', borderRadius: 3,
+  padding: '3px 10px', fontSize: 11, cursor: 'not-allowed',
+};
+const btnLink: React.CSSProperties = {
+  background: 'transparent', color: '#1565c0', border: 'none',
+  fontSize: 10, cursor: 'pointer', padding: 0,
+};
+const btnLinkDanger: React.CSSProperties = { ...btnLink, color: '#c62828' };
+const annCard: React.CSSProperties = {
+  border: '1px solid #e8e8e8', borderRadius: 4, padding: '6px 8px',
+  marginBottom: 6, background: '#fafafa',
+};
+
+function intentBadge(intent: string): React.CSSProperties {
+  const colors: Record<string, { bg: string; fg: string }> = {
+    KEY_LEVEL:        { bg: '#fff3e0', fg: '#e65100' },
+    RETEST_ENTRY:     { bg: '#e3f2fd', fg: '#1565c0' },
+    BREAKOUT_CONFIRM: { bg: '#e8f5e9', fg: '#2e7d32' },
+    REJECT_ON_TOUCH:  { bg: '#fce4ec', fg: '#c2185b' },
+    OVERTHROW_WATCH:  { bg: '#f3e5f5', fg: '#7E57C2' },
+    ABC_PROJECTION:   { bg: '#ede7f6', fg: '#4527A0' },
+    INVALIDATION:     { bg: '#ffebee', fg: '#c62828' },
+    TARGET:           { bg: '#e0f7fa', fg: '#00838f' },
+  };
+  const c = colors[intent] || { bg: '#eee', fg: '#333' };
+  return {
+    fontSize: 9, padding: '1px 6px', borderRadius: 8,
+    background: c.bg, color: c.fg, fontWeight: 600, letterSpacing: 0.3,
+  };
+}

--- a/ui/chart-draw-app/src/aitrader/annotations/api.ts
+++ b/ui/chart-draw-app/src/aitrader/annotations/api.ts
@@ -1,0 +1,51 @@
+import { getApiUrl } from '../../config/api';
+import { withAuth } from '../../utils/apiHelper';
+import type {
+  DrawingAnnotation, SymbolThesis,
+  SaveAnnotationRequest, SaveThesisRequest,
+} from './types';
+
+const BASE = '/api/ai-trader/annotations';
+
+async function jsonOrThrow<T>(res: Response): Promise<T> {
+  if (!res.ok) throw new Error((await res.text()) || `HTTP ${res.status}`);
+  if (res.status === 204) return undefined as unknown as T;
+  return res.json() as Promise<T>;
+}
+
+export async function listAnnotations(symbol: string, tabUuid?: string): Promise<DrawingAnnotation[]> {
+  const qs = new URLSearchParams({ symbol });
+  if (tabUuid) qs.set('tabUuid', tabUuid);
+  const res = await fetch(getApiUrl(`${BASE}?${qs.toString()}`).toString(), withAuth());
+  return jsonOrThrow(res);
+}
+
+export async function saveAnnotation(req: SaveAnnotationRequest): Promise<DrawingAnnotation> {
+  const res = await fetch(getApiUrl(BASE).toString(), withAuth({
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  }));
+  return jsonOrThrow(res);
+}
+
+export async function deleteAnnotation(id: number): Promise<void> {
+  const res = await fetch(getApiUrl(`${BASE}/${id}`).toString(), withAuth({ method: 'DELETE' }));
+  if (!res.ok) throw new Error((await res.text()) || `HTTP ${res.status}`);
+}
+
+export async function getThesis(symbol: string, tabUuid: string): Promise<SymbolThesis | null> {
+  const qs = new URLSearchParams({ symbol, tabUuid });
+  const res = await fetch(getApiUrl(`${BASE}/thesis?${qs.toString()}`).toString(), withAuth());
+  if (res.status === 204) return null;
+  return jsonOrThrow(res);
+}
+
+export async function saveThesis(req: SaveThesisRequest): Promise<SymbolThesis> {
+  const res = await fetch(getApiUrl(`${BASE}/thesis`).toString(), withAuth({
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  }));
+  return jsonOrThrow(res);
+}

--- a/ui/chart-draw-app/src/aitrader/annotations/types.ts
+++ b/ui/chart-draw-app/src/aitrader/annotations/types.ts
@@ -1,0 +1,73 @@
+export type AnnotationIntent =
+  | 'KEY_LEVEL'
+  | 'RETEST_ENTRY'
+  | 'BREAKOUT_CONFIRM'
+  | 'REJECT_ON_TOUCH'
+  | 'OVERTHROW_WATCH'
+  | 'ABC_PROJECTION'
+  | 'INVALIDATION'
+  | 'TARGET';
+
+export const INTENT_LABELS: Record<AnnotationIntent, string> = {
+  KEY_LEVEL:        'Key level (importance flag)',
+  RETEST_ENTRY:     'Retest entry',
+  BREAKOUT_CONFIRM: 'Breakout confirmation',
+  REJECT_ON_TOUCH:  'Reject on touch (fade)',
+  OVERTHROW_WATCH:  'Overthrow watch',
+  ABC_PROJECTION:   'ABC projection',
+  INVALIDATION:     'Invalidation level',
+  TARGET:           'Target',
+};
+
+export const INTENT_ORDER: AnnotationIntent[] = [
+  'KEY_LEVEL', 'RETEST_ENTRY', 'BREAKOUT_CONFIRM', 'REJECT_ON_TOUCH',
+  'OVERTHROW_WATCH', 'ABC_PROJECTION', 'INVALIDATION', 'TARGET',
+];
+
+export interface DrawingAnnotation {
+  id: number;
+  tabUuid: string;
+  symbol: string;
+  interval?: string;
+  drawingId: string;
+  intent: AnnotationIntent;
+  intentParamsJson?: string;
+  geometryJson?: string;
+  note?: string;
+  weight: number;
+  active: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface SymbolThesis {
+  id?: number;
+  tabUuid: string;
+  symbol: string;
+  bias?: string;
+  regime?: string;
+  horizonDays?: number;
+  thesisText?: string;
+  updatedAt?: string;
+}
+
+export interface SaveAnnotationRequest {
+  tabUuid: string;
+  symbol: string;
+  interval?: string;
+  drawingId?: string;
+  intent: AnnotationIntent;
+  intentParamsJson?: string;
+  geometryJson?: string;
+  note?: string;
+  weight?: number;
+}
+
+export interface SaveThesisRequest {
+  tabUuid: string;
+  symbol: string;
+  bias?: string;
+  regime?: string;
+  horizonDays?: number;
+  thesisText?: string;
+}


### PR DESCRIPTION
Closes #207

## Summary
- Trader can attach a structured **intent** + free-text **note** to any drawing (Trendline / Triangle / ABC / horizontal / etc.), plus a per-symbol **thesis** with bias + regime.
- Both ride into the LevelsAgent and PatternAgent prompts, sorted by weight, so the agents act on the trader's stated intent instead of analyzing the chart cold every run.

## Intent vocabulary (typed params)
| Intent | Params |
|---|---|
| KEY_LEVEL | (just an importance flag) |
| RETEST_ENTRY | tolerance_pct, side |
| BREAKOUT_CONFIRM | confirmation_bars, side |
| REJECT_ON_TOUCH | tolerance_pct |
| OVERTHROW_WATCH | max_overthrow_pct, expected_settle_bars |
| ABC_PROJECTION | ratios: [1.0, 1.272, 1.618, …] |
| INVALIDATION / TARGET | side |

## Wiring
- \`AnnotationBundleBuilder.buildForLevels(userId, symbol, tabUuid)\` — tab-scoped, used by LevelsAgent.
- \`AnnotationBundleBuilder.buildForPattern(userId, symbol)\` — user+symbol-scoped (any tab), used by PatternAgent.
- \`toPromptSection(bundle)\` renders a Markdown fragment injected after the as-of timestamp (Levels) / PATTERN SIGNAL (Pattern) block, before the indicator dump. Caps at 25 annotations and 200-char notes.

## Frontend
New 4th collapsible \`Annotations & thesis\` section on \`/ai-trader\`'s right column:
- Inline thesis editor (bias dropdown + regime + thesis textarea + Save)
- Add/Edit modal with intent dropdown + dynamic param fields + note + weight (1-5)
- Per-annotation cards with badges + edit/delete

## Schema
\`ddl-auto=update\` auto-creates two tables on next boot:
- \`chart_drawing_annotation\` — unique \`(user_id, tab_uuid, symbol, drawing_id)\`
- \`symbol_thesis\` — unique \`(user_id, tab_uuid, symbol)\`

## Test plan
- [x] \`./gradlew compileJava\` clean
- [x] \`npm run build\` clean
- [x] Backend boots; Hibernate creates both tables
- [x] \`PUT /thesis\` saves and returns the DTO
- [x] \`POST /annotations\` (RETEST_ENTRY with tolerance + side) saves with auto-generated drawing_id
- [x] \`POST /annotations\` (ABC_PROJECTION with [1.0, 1.272, 1.618]) saves
- [x] \`GET /bundle\` returns thesis + annotations sorted by weight DESC
- [ ] (not in this PR) Verify agent prompt actually contains the fragment in a live LevelsAgent run

## Out of scope (next PRs)
- \`LevelWatchSynth\` — auto-derive \`level_watch\` rows from RETEST_ENTRY / TARGET / INVALIDATION so price touches fire the AI pipeline.
- TradingView widget \"select drawing → open annotation panel\" UX wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)