### PR TITLE
fix(aitrader): sim-trade click pans chart + draws entry/SL/TP (no remount)

### DIFF
--- a/ui/chart-draw-app/src/aitrader/AiTraderPage.tsx
+++ b/ui/chart-draw-app/src/aitrader/AiTraderPage.tsx
@@ -46,6 +46,7 @@ export default function AiTraderPage() {
 
   const chartRef = useRef<any>(null);
   const aiShapeIdsRef = useRef<any[]>([]);
+  const simTradeShapeIdsRef = useRef<any[]>([]);
   const tabId = getOrCreateTabId();
 
   // Single source of truth for symbol changes — also bumps refreshTick so dependent panels re-fetch.
@@ -69,6 +70,67 @@ export default function AiTraderPage() {
     setToast({ msg, kind });
     setTimeout(() => setToast(null), 5000);
   }, []);
+
+  // Pan the chart to a simulated trade and draw entry/SL/TP horizontals.
+  // We deliberately go through chartRef directly — no React state changes — so the
+  // TVChartContainer widget does NOT remount (which would look like a page refresh).
+  const handleSelectSimTrade = useCallback(async (trade: any) => {
+    if (!chartRef.current) { showToast('Chart not ready', 'error'); return; }
+    const chart = chartRef.current;
+    const symbol = trade.symbol;
+    const direction = trade.direction;
+    const entry = Number(trade.entryPrice ?? trade.entry_price);
+    const sl = Number(trade.stopInitial ?? trade.stop_initial);
+    const target = Number(trade.targetInitial ?? trade.target_initial);
+    const entryEpoch = isoToEpochSec(trade.entryTime ?? trade.entry_time);
+    const exitEpoch = isoToEpochSec(trade.exitTime ?? trade.exit_time) || (entryEpoch + 7 * 86400);
+
+    // If a stray different-symbol trade ever lands here, switch via TV API (no remount).
+    if (symbol && symbol !== selectedSymbol) {
+      try { chart.setSymbol?.(symbol, () => {}); } catch (e) { console.warn('setSymbol failed', e); }
+    }
+
+    // Pan to entry/exit window with a 30% buffer on each side.
+    if (entryEpoch > 0) {
+      const duration = Math.max(86400, exitEpoch - entryEpoch);
+      const buffer = duration * 0.3;
+      try {
+        chart.setVisibleRange({ from: entryEpoch - buffer, to: exitEpoch + buffer });
+      } catch (e) { console.warn('setVisibleRange failed', e); }
+    }
+
+    // Clear previous sim-trade shapes
+    for (const id of simTradeShapeIdsRef.current) {
+      try { chart.removeEntity(id); } catch {}
+    }
+    simTradeShapeIdsRef.current = [];
+
+    // Draw entry/SL/TP horizontals anchored at entryEpoch.
+    const drawLine = async (price: number, color: string, label: string) => {
+      if (!Number.isFinite(price)) return;
+      try {
+        const id = await chart.createShape(
+          { time: entryEpoch || Math.floor(Date.now() / 1000), price },
+          { shape: 'horizontal_line', lock: false, disableSelection: false, disableSave: true, disableUndo: true, text: label }
+        );
+        if (id) {
+          try {
+            const shape = chart.getShapeById(id);
+            shape?.setProperties?.({ linecolor: color, linewidth: 1, linestyle: 0, textcolor: color, showLabel: true });
+          } catch {}
+          simTradeShapeIdsRef.current.push(id);
+        }
+      } catch (e) { console.warn('drawLine failed', label, e); }
+    };
+
+    const entryColor = direction === 'LONG' ? '#2e7d32' : '#c62828';
+    drawLine(entry, entryColor, `Entry ${direction}`);
+    drawLine(sl, '#EF5350', 'SL');
+    drawLine(target, '#26A69A', 'Target');
+
+    const when = (trade.entryTime ?? trade.entry_time ?? '').toString().substring(0, 16).replace('T', ' ');
+    showToast(`${symbol} ${direction} · ${when} · entry ${entry.toFixed(2)}`);
+  }, [selectedSymbol, showToast]);
 
   const handleAiLevels = useCallback(async () => {
     if (!chartRef.current) { showToast('Chart not ready', 'error'); return; }
@@ -219,7 +281,11 @@ export default function AiTraderPage() {
           <WatchTradesPanel symbol={selectedSymbol} onSelectSymbol={handleSelectSymbol} refreshTick={refreshTick} />
         </CollapsibleSection>
         <CollapsibleSection title={`Simulated trades · ${selectedSymbol}`} defaultOpen={false}>
-          <SimulatedTradesPanel symbol={selectedSymbol} onSelectSymbol={handleSelectSymbol} />
+          <SimulatedTradesPanel
+            symbol={selectedSymbol}
+            onSelectSymbol={handleSelectSymbol}
+            onSelectTrade={handleSelectSimTrade}
+          />
         </CollapsibleSection>
       </div>
 

--- a/ui/chart-draw-app/src/aitrader/SimulatedTradesPanel.tsx
+++ b/ui/chart-draw-app/src/aitrader/SimulatedTradesPanel.tsx
@@ -38,12 +38,21 @@ type Replay = {
   modelUsed: string;
 };
 
-type Props = { symbol?: string; onSelectSymbol: (s: string) => void };
+type Props = {
+  symbol?: string;
+  onSelectSymbol: (s: string) => void;
+  /**
+   * Invoked when the trader clicks the trade row. Receives the full trade object
+   * so the parent can pan/decorate the chart for the trade window without
+   * triggering a symbol-change re-render. When omitted, falls back to onSelectSymbol.
+   */
+  onSelectTrade?: (trade: SimTrade) => void;
+};
 
 const f = (n: any, dp = 2) => (n == null ? '-' : Number(n).toFixed(dp));
 const truncate = (s: string, n: number) => (s && s.length > n ? s.substring(0, n) + '…' : s);
 
-export default function SimulatedTradesPanel({ symbol, onSelectSymbol }: Props) {
+export default function SimulatedTradesPanel({ symbol, onSelectSymbol, onSelectTrade }: Props) {
   const [runs, setRuns] = useState<SimRun[]>([]);
   const [loading, setLoading] = useState(false);
   const [groupExpanded, setGroupExpanded] = useState<Record<string, boolean>>({});
@@ -199,7 +208,13 @@ export default function SimulatedTradesPanel({ symbol, onSelectSymbol }: Props) 
                         borderBottom: '1px solid #f5f5f5', background: '#fff',
                       }}>
                         <div style={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 8}}>
-                          <div onClick={() => onSelectSymbol(t.symbol)} style={{flex: 1, cursor: 'pointer'}}>
+                          <div
+                            onClick={() => {
+                              if (onSelectTrade) onSelectTrade(t);
+                              else onSelectSymbol(t.symbol);
+                            }}
+                            style={{flex: 1, cursor: 'pointer'}}
+                          >
                             <span style={{
                               fontWeight: 600,
                               color: direction === 'LONG' ? '#2e7d32' : '#c62828',


### PR DESCRIPTION
Closes #209

## Summary
Clicking a simulated trade in the right column previously did two wrong things at once:
1. Triggered a TradingView widget **remount** (the \"page refresh\" you saw), via a chain of \`onSelectSymbol\` → \`setRefreshTick\` → \`AiTraderPage\` re-render → new \`onChartReady\` arrow → \`TVChartContainer\` useEffect re-fires → widget recreated.
2. Did **not** navigate the chart to the trade's actual time window or draw entry/SL/TP.

This PR fixes both:
- New \`onSelectTrade(trade)\` callback on \`SimulatedTradesPanel\` (preferred over \`onSelectSymbol\` when provided).
- \`AiTraderPage.handleSelectSimTrade\` uses \`chartRef\` directly — no React state change, no widget remount.
- Pans the chart via \`chart.setVisibleRange\` to [entry − 30%, exit + 30%].
- Draws three horizontal lines for entry (direction-coloured), SL (red), target (green) via \`chart.createShape\`. Previous lines cleared on next trade click.
- If a stray different-symbol trade ever lands here, falls back to \`chart.setSymbol()\` (TV API) instead of triggering a React state change.

## Test plan
- [x] \`npm run build\` clean
- [ ] (manual) Open \`/ai-trader\`, expand a simulated run, click a trade → chart pans to its window with entry/SL/TP drawn; no widget remount/flicker

🤖 Generated with [Claude Code](https://claude.com/claude-code)