### PR TITLE
fix(aitrader): persist TV drawings + collapsible side panels

### DIFF
--- a/ui/chart-draw-app/src/aitrader/AiTraderPage.tsx
+++ b/ui/chart-draw-app/src/aitrader/AiTraderPage.tsx
@@ -28,6 +28,29 @@ function getOrCreateTabId(): string {
   return id;
 }
 
+// Small chevron tab that overlays the inner edge of a side panel.
+// side='right' → tab on the right edge (used by the left watchlist panel).
+// side='left'  → tab on the left edge (used by the right stack panel).
+function collapseTabStyle(side: 'left' | 'right'): React.CSSProperties {
+  return {
+    position: 'absolute',
+    top: 8,
+    [side]: 2,
+    width: 18, height: 22,
+    background: '#fff',
+    border: '1px solid #ddd',
+    borderRadius: 3,
+    cursor: 'pointer',
+    fontSize: 12,
+    color: '#666',
+    padding: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 5,
+  };
+}
+
 function isoToEpochSec(t: any): number {
   if (typeof t === 'number') return t > 1e12 ? Math.floor(t / 1000) : t;
   if (typeof t === 'string') {
@@ -157,6 +180,27 @@ export default function AiTraderPage() {
   const [aiLoading, setAiLoading] = useState(false);
   const [analyseLoading, setAnalyseLoading] = useState(false);
   const [toast, setToast] = useState<{msg: string; kind: 'success'|'error'} | null>(null);
+  // Panel collapse state — persisted so the trader's layout survives refresh.
+  const [leftCollapsed, setLeftCollapsed] = useState<boolean>(() =>
+    localStorage.getItem('aitrader_left_collapsed') === '1'
+  );
+  const [rightCollapsed, setRightCollapsed] = useState<boolean>(() =>
+    localStorage.getItem('aitrader_right_collapsed') === '1'
+  );
+  const toggleLeft = useCallback(() => {
+    setLeftCollapsed(v => {
+      const next = !v;
+      localStorage.setItem('aitrader_left_collapsed', next ? '1' : '0');
+      return next;
+    });
+  }, []);
+  const toggleRight = useCallback(() => {
+    setRightCollapsed(v => {
+      const next = !v;
+      localStorage.setItem('aitrader_right_collapsed', next ? '1' : '0');
+      return next;
+    });
+  }, []);
 
   const chartRef = useRef<any>(null);
   const aiShapeIdsRef = useRef<any[]>([]);
@@ -394,16 +438,35 @@ export default function AiTraderPage() {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'row', height: '100vh', overflow: 'hidden' }}>
-      {/* Left: Watchlist */}
-      <div style={{ width: 260, borderRight: '1px solid #ddd', overflowY: 'auto', background: '#fff' }}>
-        <WatchlistPanel
-          onSelectSymbol={handleSelectSymbol}
-          onBatchComplete={() => setRefreshTick(t => t + 1)}
-        />
-      </div>
+      {/* Left: Watchlist (collapsible) */}
+      {!leftCollapsed && (
+        <div style={{ width: 260, borderRight: '1px solid #ddd', overflowY: 'auto', background: '#fff', position: 'relative' }}>
+          <button
+            onClick={toggleLeft}
+            title="Collapse watchlist"
+            style={collapseTabStyle('right')}
+          >‹</button>
+          <WatchlistPanel
+            onSelectSymbol={handleSelectSymbol}
+            onBatchComplete={() => setRefreshTick(t => t + 1)}
+          />
+        </div>
+      )}
+      {leftCollapsed && (
+        <button
+          onClick={toggleLeft}
+          title="Expand watchlist"
+          style={{
+            width: 18, borderRight: '1px solid #ddd', background: '#f5f5f5',
+            cursor: 'pointer', border: 'none', borderLeft: 'none',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 14, color: '#666',
+          }}
+        >›</button>
+      )}
 
       {/* Center: toolbar + chart */}
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', borderRight: '1px solid #ddd', background: '#fff' }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', borderRight: rightCollapsed ? 'none' : '1px solid #ddd', background: '#fff' }}>
         {/* Toolbar */}
         <div style={{
           display: 'flex', alignItems: 'center', gap: 8,
@@ -442,6 +505,7 @@ export default function AiTraderPage() {
           <TVChartContainer
             symbol={selectedSymbol}
             timeframe="OneHour"
+            tabId={tabId}
             onChartReady={(chart) => {
               chartRef.current = chart;
               // Sync the React state when user changes symbol via TV's own search bar
@@ -458,8 +522,26 @@ export default function AiTraderPage() {
         </div>
       </div>
 
-      {/* Right: 3 stacked panels */}
-      <div style={{ width: 320, borderLeft: '1px solid #ddd', overflowY: 'auto', background: '#fff' }}>
+      {/* Right: 3 stacked panels (collapsible) */}
+      {rightCollapsed && (
+        <button
+          onClick={toggleRight}
+          title="Expand panels"
+          style={{
+            width: 18, borderLeft: '1px solid #ddd', background: '#f5f5f5',
+            cursor: 'pointer', border: 'none',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 14, color: '#666',
+          }}
+        >‹</button>
+      )}
+      {!rightCollapsed && (
+      <div style={{ width: 320, borderLeft: '1px solid #ddd', overflowY: 'auto', background: '#fff', position: 'relative' }}>
+        <button
+          onClick={toggleRight}
+          title="Collapse panels"
+          style={collapseTabStyle('left')}
+        >›</button>
         <CollapsibleSection title={`Active trades · ${selectedSymbol}`} defaultOpen={true}>
           <ActiveTradesPanel symbol={selectedSymbol} onSelectSymbol={handleSelectSymbol} refreshTick={refreshTick} />
         </CollapsibleSection>
@@ -477,6 +559,7 @@ export default function AiTraderPage() {
           <AnnotationsPanel symbol={selectedSymbol} tabUuid={tabId} interval="OneHour" />
         </CollapsibleSection>
       </div>
+      )}
 
       {/* Toast */}
       {toast && (

--- a/ui/chart-draw-app/src/tradingview/TVChartContainer.tsx
+++ b/ui/chart-draw-app/src/tradingview/TVChartContainer.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import datafeed from './datafeed';
-import { mapTimeframeToInterval } from './intervalUtils';
+import { mapTimeframeToInterval, intervalToPeriod } from './intervalUtils';
+import { createSaveLoadAdapter } from './saveLoadAdapter';
 
 // TradingView types (loaded globally via script tag)
 declare const TradingView: any;
@@ -31,6 +32,12 @@ type Props = {
   visibleRange?: { from: number; to: number }; // unix seconds
   autoStudies?: Study[];
   customIndicators?: any[];  // array of CustomIndicator objects to register
+  /**
+   * If provided, drawings/templates are persisted to the backend via
+   * /api/chart-state/drawings keyed by ({tabId}:{symbol}, layoutId, timeframe).
+   * Survives page refresh. Omit to disable persistence (widget-memory only).
+   */
+  tabId?: string;
 };
 
 export default function TVChartContainer({
@@ -41,6 +48,7 @@ export default function TVChartContainer({
   visibleRange,
   autoStudies = [],
   customIndicators = [],
+  tabId,
 }: Props) {
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const widgetRef = useRef<any>(null);
@@ -53,16 +61,35 @@ export default function TVChartContainer({
   const onChartReadyRef = useRef(onChartReady);
   const autoStudiesRef = useRef(autoStudies);
   const customIndicatorsRef = useRef(customIndicators);
+  // symbol/timeframe/tabId tracked in refs so the saveLoadAdapter context closure
+  // reads the latest values (e.g. when the user changes symbol via TV's search bar).
+  const symbolRef = useRef(symbol);
+  const timeframeRef = useRef(timeframe);
+  const tabIdRef = useRef(tabId);
   useEffect(() => { onChartReadyRef.current = onChartReady; }, [onChartReady]);
   useEffect(() => { autoStudiesRef.current = autoStudies; }, [autoStudies]);
   useEffect(() => { customIndicatorsRef.current = customIndicators; }, [customIndicators]);
+  useEffect(() => { symbolRef.current = symbol; }, [symbol]);
+  useEffect(() => { timeframeRef.current = timeframe; }, [timeframe]);
+  useEffect(() => { tabIdRef.current = tabId; }, [tabId]);
 
   const interval = mapTimeframeToInterval(timeframe);
 
   useEffect(() => {
     if (!chartContainerRef.current) return;
 
-    const widgetOptions = {
+    // Build the save/load adapter only when tabId is provided. Without it, drawings stay in
+    // widget memory (the legacy behaviour). With it, drawings are scoped to
+    // (tabId:symbol, layoutId, timeframe) and round-trip through /api/chart-state/drawings.
+    const saveLoadAdapter = tabIdRef.current
+      ? createSaveLoadAdapter(() => ({
+          symbol: symbolRef.current,
+          tabId: tabIdRef.current!,
+          timeframe: timeframeRef.current,
+        }))
+      : undefined;
+
+    const widgetOptions: any = {
       symbol: symbol,
       datafeed: datafeed,
       interval: interval,
@@ -70,7 +97,9 @@ export default function TVChartContainer({
       library_path: '/charting_library/charting_library/',
       locale: 'en',
       disabled_features: ['header_symbol_search', 'symbol_search_hot_key', 'header_compare'],
-      enabled_features: ['library_custom_no_powered_branding'],
+      enabled_features: saveLoadAdapter
+        ? ['library_custom_no_powered_branding', 'saveload_separate_drawings_storage', 'items_favoriting']
+        : ['library_custom_no_powered_branding'],
       custom_css_url: '/chart-custom.css',
       fullscreen: false,
       autosize: true,
@@ -91,6 +120,11 @@ export default function TVChartContainer({
       },
     };
 
+    if (saveLoadAdapter) {
+      widgetOptions.save_load_adapter = saveLoadAdapter;
+      widgetOptions.load_last_chart = true;
+    }
+
     const tvWidget = new TradingView.widget(widgetOptions);
     widgetRef.current = tvWidget;
 
@@ -101,6 +135,41 @@ export default function TVChartContainer({
 
         // Reset studies flag on chart ready
         studiesAddedRef.current = false;
+
+        // Keep the saveLoadAdapter's timeframe context in sync when the trader
+        // changes resolution via TV's own toolbar. Drawings save/load is scoped by
+        // (tab, symbol, timeframe), so without this update, drawings on the 15m
+        // would get filed under whatever timeframe the parent last passed.
+        try {
+          chart.onIntervalChanged().subscribe(null, () => {
+            try {
+              const tf = intervalToPeriod(chart.resolution());
+              if (tf) timeframeRef.current = tf;
+            } catch (e) { /* ignore */ }
+          });
+        } catch (e) { /* ignore — older TV versions */ }
+
+        // Persist drawings on every drawing change (debounced 2s).
+        // Mirrors TVChartApp's auto-save wiring so refresh restores trendlines etc.
+        if (saveLoadAdapter) {
+          let saveTimeout: number | null = null;
+          const triggerDrawingSave = () => {
+            if (saveTimeout) clearTimeout(saveTimeout);
+            saveTimeout = window.setTimeout(async () => {
+              try {
+                const state = chart.getLineToolsState();
+                await saveLoadAdapter.saveLineToolsAndGroups(undefined, chart.id(), state);
+              } catch (e) {
+                console.error('[TVChartContainer] auto-save drawings failed:', e);
+              }
+            }, 2000);
+          };
+          try {
+            tvWidget.subscribe('drawing_event', triggerDrawingSave);
+          } catch (e) {
+            console.warn('[TVChartContainer] could not subscribe to drawing_event:', e);
+          }
+        }
 
         // ---- Studies ----
         const studiesNow = autoStudiesRef.current || [];


### PR DESCRIPTION
## Drawings disappear on refresh
`TVChartContainer` (the widget on `/ai-trader`) never wired TradingView's `save_load_adapter`. The legacy `/tv-chart` page (`TVChartApp`) does — so trendlines persist there. Mirroring that here:

- Add optional `tabId` prop. When provided, build `createSaveLoadAdapter()` and pass it as `save_load_adapter` + `enabled_features: ['saveload_separate_drawings_storage', 'items_favoriting']` + `load_last_chart: true`.
- Subscribe to `drawing_event` with 2s debounce → `saveLoadAdapter.saveLineToolsAndGroups` (same pattern as TVChartApp).
- Backend endpoint `/api/chart-state/drawings` already exists and already keys by `(tabId:symbol, layoutId, timeframe)`. No backend change.

## Per-timeframe scoping
Subscribe to `chart.onIntervalChanged` so `timeframeRef` updates on every resolution change. Drawings on 15m vs 1h save into different rows; switching back and forth restores each set.

## Collapsible side panels
- `leftCollapsed`, `rightCollapsed` state persisted to `localStorage` (`aitrader_left_collapsed` / `aitrader_right_collapsed`).
- Each panel has a small chevron toggle at its inner edge. Collapsed → 18px gutter with a chevron; chart fills the freed width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)