### PR TITLE
fix(tradingview): encode timeframe into drawings storage key (sidestep legacy unique constraint)

### DIFF
--- a/ui/chart-draw-app/src/tradingview/saveLoadAdapter.ts
+++ b/ui/chart-draw-app/src/tradingview/saveLoadAdapter.ts
@@ -71,10 +71,15 @@ export interface AdapterContext {
   timeframe?: string;
 }
 
-// Maps a (tabId, symbol) pair to a scoped key for the drawings backend API.
-// This isolates each tab's drawings from other tabs with the same symbol.
+// Maps a (tabId, symbol, timeframe) tuple to a scoped key for the drawings backend.
+// Tabs isolated from each other; per-timeframe scoping nested inside that. The
+// timeframe component is appended into the `symbol` column rather than relying on
+// the dedicated timeframe column because user_chart_state has a legacy unique key
+// on (symbol, layout_id) that doesn't include timeframe — without encoding the TF
+// here, saves collide with any pre-existing null-timeframe row.
 function scopedSymbol(ctx: AdapterContext): string {
-  return `${ctx.tabId}:${ctx.symbol}`;
+  const base = `${ctx.tabId}:${ctx.symbol}`;
+  return ctx.timeframe ? `${base}:${ctx.timeframe}` : base;
 }
 
 export function createSaveLoadAdapter(getContext: () => AdapterContext) {
@@ -225,25 +230,32 @@ export function createSaveLoadAdapter(getContext: () => AdapterContext) {
           : actualLayoutId;
 
         const ctx = getContext();
-        const url = getApiUrl('/api/chart-state/drawings');
-        url.searchParams.set('symbol', scopedSymbol(ctx));
-        url.searchParams.set('layoutId', String(numericLayoutId));
-        if (ctx.timeframe) {
-          url.searchParams.set('timeframe', ctx.timeframe);
-        }
 
-        const response = await apiFetch(url.toString(), withAuth());
+        // Try keys in order: per-TF composite, then legacy non-TF composite (for one-time
+        // migration of drawings saved before TF was encoded into the symbol column).
+        const candidateSymbols: string[] = [];
+        candidateSymbols.push(scopedSymbol(ctx));
+        if (ctx.timeframe) candidateSymbols.push(`${ctx.tabId}:${ctx.symbol}`);
 
-        if (response.ok) {
+        for (const symbolKey of candidateSymbols) {
+          const url = getApiUrl('/api/chart-state/drawings');
+          url.searchParams.set('symbol', symbolKey);
+          url.searchParams.set('layoutId', String(numericLayoutId));
+          if (ctx.timeframe) url.searchParams.set('timeframe', ctx.timeframe);
+
+          const response = await apiFetch(url.toString(), withAuth());
+          if (!response.ok) continue;
           const drawings = await response.json();
+          const hasContent = drawings && (
+            (drawings.sources && Object.keys(drawings.sources).length > 0) ||
+            (drawings.groups && Object.keys(drawings.groups).length > 0)
+          );
+          if (!hasContent) continue;
 
-          // Convert top-level plain objects back to Maps for TradingView
-          const stateWithMaps = {
+          return {
             sources: drawings.sources ? new Map(Object.entries(drawings.sources)) : new Map(),
             groups: drawings.groups ? new Map(Object.entries(drawings.groups)) : new Map(),
           };
-
-          return stateWithMaps;
         }
         return null;
       } catch (e) {


### PR DESCRIPTION
Drawings on `/ai-trader` were saving and failing with:

```
Duplicate entry '<tabId>:<symbol>-<layoutId>' for key 'user_chart_state.UKmv6mtbw9povrfv72ja150ydlp'
```

That unique index is on `(symbol, layout_id)` only — it predates per-timeframe support. Pre-existing legacy rows (null-timeframe) collide with new per-TF inserts.

Two ways to fix: DDL on the unique key, or encode the timeframe into the composite `symbol` column. Going with the latter — no DB touch.

`scopedSymbol(ctx)` now returns `${tabId}:${symbol}:${timeframe}` when a timeframe is in context, vs `${tabId}:${symbol}` before. The unique-key collision is gone, and drawings on 15m vs 1h end up in different rows — matching the "save per timeframe for readability" ask.

Load also falls back to the legacy non-TF symbol once if the new per-TF key returns nothing, so existing /tv-chart users see their prior drawings on first load (next save then writes under the new key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)