### PR TITLE
feat(aitrader): AI Analyse — bilateral default, candle pattern tags, annotation bundle

### DIFF
--- a/src/main/java/com/dtech/aitrader/service/AiAnalysePromptBuilder.java
+++ b/src/main/java/com/dtech/aitrader/service/AiAnalysePromptBuilder.java
@@ -45,14 +45,25 @@ public class AiAnalysePromptBuilder {
 
     /**
      * Builds a comprehensive prompt for generating watch trades.
-     *
-     * @param symbol The stock symbol
-     * @param tabId User's tab ID for scoped drawing lookup
-     * @param layoutId Chart layout ID
-     * @param timeframe Timeframe (e.g. "OneHour")
-     * @return User prompt with bars, indicators, drawings, and AI levels
      */
     public String buildAnalysePrompt(String symbol, String tabId, Long layoutId, String timeframe) {
+        return buildAnalysePrompt(symbol, tabId, layoutId, timeframe, "");
+    }
+
+    /**
+     * Builds a comprehensive prompt for generating watch trades, with an optional
+     * pre-rendered trader-annotations fragment injected up front.
+     *
+     * @param symbol               The stock symbol
+     * @param tabId                User's tab ID for scoped drawing lookup
+     * @param layoutId             Chart layout ID
+     * @param timeframe            Timeframe (e.g. "OneHour")
+     * @param annotationsFragment  Pre-rendered Markdown section from AnnotationBundleBuilder,
+     *                             or empty/null when no annotations are configured.
+     * @return User prompt with bars, indicators, drawings, AI levels, and trader intent
+     */
+    public String buildAnalysePrompt(String symbol, String tabId, Long layoutId, String timeframe,
+                                     String annotationsFragment) {
         StringBuilder prompt = new StringBuilder();
 
         // 1. Header with context
@@ -60,19 +71,30 @@ public class AiAnalysePromptBuilder {
         prompt.append(String.format("Symbol: %s | Timeframe: %s\n", symbol, timeframe));
         prompt.append(String.format("Generated At: %s UTC\n\n", formatIsoDateTime(Instant.now().getEpochSecond())));
 
-        // 2. Recent hourly bars (last 100)
+        // 2. Trader annotations — placed up front so the agent reads stated intent
+        // (KEY_LEVEL, REJECT_ON_TOUCH, OVERTHROW_WATCH, etc.) before the data dump.
+        if (annotationsFragment != null && !annotationsFragment.isBlank()) {
+            prompt.append(annotationsFragment);
+            if (!annotationsFragment.endsWith("\n\n")) prompt.append("\n");
+        }
+
+        // 3. Recent bars
         appendHourlyBars(prompt, symbol, timeframe);
 
-        // 3. Current hourly indicators
+        // 4. Recent candle patterns — pre-classify so the AI doesn't have to spot
+        // a bearish-engulfing or pin-bar from raw OHLC and miss it.
+        appendCandlePatterns(prompt, symbol, timeframe);
+
+        // 5. Current indicators
         appendHourlyIndicators(prompt, symbol, timeframe);
 
-        // 4. Today's AI horizontal levels
+        // 6. Today's AI horizontal levels
         appendAiHorizontalLevels(prompt, symbol, timeframe);
 
-        // 5. User's drawn lines for this symbol
+        // 7. User's drawn lines for this symbol
         appendUserDrawings(prompt, symbol, tabId, layoutId, timeframe);
 
-        // 6. Decision instructions with strict JSON output
+        // 8. Decision instructions with strict JSON output
         appendDecisionInstructions(prompt);
 
         log.debug("Built analyse prompt for symbol={}, timeframe={}, length={} chars (~{} tokens)",
@@ -192,6 +214,79 @@ public class AiAnalysePromptBuilder {
             log.warn("Error fetching AI levels for {}", symbol, e);
             prompt.append("## AI Horizontal Levels\n(error fetching levels)\n\n");
         }
+    }
+
+    /**
+     * Classifies the last few candles into named price-action patterns the AI can
+     * key off explicitly. Doesn't try to be exhaustive — just flags the patterns
+     * that most often anchor trader decisions: engulfing, hammer/shooting-star,
+     * doji, inside bar.
+     */
+    private void appendCandlePatterns(StringBuilder prompt, String symbol, String timeframe) {
+        try {
+            List<OhlcBarDTO> bars = chartDataService.getBars(symbol, timeframe, null, null, false);
+            if (bars.size() < 6) {
+                prompt.append("## Recent Candle Patterns\n(not enough bars to classify)\n\n");
+                return;
+            }
+            // Look at the last 5 bars (with each one's predecessor for two-candle patterns).
+            int n = bars.size();
+            prompt.append("## Recent Candle Patterns (last 5 bars)\n");
+            for (int offset = 4; offset >= 0; offset--) {
+                OhlcBarDTO prev = bars.get(n - 2 - offset);
+                OhlcBarDTO cur  = bars.get(n - 1 - offset);
+                List<String> tags = classifyCandle(prev, cur);
+                String label = tags.isEmpty() ? "(no notable pattern)" : String.join(", ", tags);
+                prompt.append(String.format("  - %s  →  %s\n",
+                        formatIsoDateTime(cur.getTime()), label));
+            }
+            prompt.append("\n");
+        } catch (Exception e) {
+            log.warn("Error classifying candle patterns for {}", symbol, e);
+            prompt.append("## Recent Candle Patterns\n(error classifying)\n\n");
+        }
+    }
+
+    private List<String> classifyCandle(OhlcBarDTO prev, OhlcBarDTO cur) {
+        List<String> tags = new ArrayList<>();
+        double bodyCur  = Math.abs(cur.getClose() - cur.getOpen());
+        double rangeCur = Math.max(1e-9, cur.getHigh() - cur.getLow());
+        double upperWick = cur.getHigh() - Math.max(cur.getOpen(), cur.getClose());
+        double lowerWick = Math.min(cur.getOpen(), cur.getClose()) - cur.getLow();
+        boolean curGreen = cur.getClose() > cur.getOpen();
+        boolean prevGreen = prev.getClose() > prev.getOpen();
+
+        // Engulfing — two-candle reversal
+        if (!curGreen && prevGreen
+                && cur.getOpen() >= prev.getClose()
+                && cur.getClose() <= prev.getOpen()) {
+            tags.add("bearish_engulfing");
+        }
+        if (curGreen && !prevGreen
+                && cur.getOpen() <= prev.getClose()
+                && cur.getClose() >= prev.getOpen()) {
+            tags.add("bullish_engulfing");
+        }
+
+        // Pin-bar style: small body, long wick on one side
+        if (bodyCur < 0.35 * rangeCur && lowerWick > 1.8 * bodyCur && lowerWick > upperWick) {
+            tags.add("hammer / bullish_pin");
+        }
+        if (bodyCur < 0.35 * rangeCur && upperWick > 1.8 * bodyCur && upperWick > lowerWick) {
+            tags.add("shooting_star / bearish_pin");
+        }
+
+        // Doji
+        if (bodyCur < 0.10 * rangeCur) {
+            tags.add("doji");
+        }
+
+        // Inside bar
+        if (cur.getHigh() < prev.getHigh() && cur.getLow() > prev.getLow()) {
+            tags.add("inside_bar");
+        }
+
+        return tags;
     }
 
     private void appendUserDrawings(StringBuilder prompt, String symbol, String tabId, Long layoutId, String timeframe) {

--- a/src/main/java/com/dtech/aitrader/service/AiAnalyseService.java
+++ b/src/main/java/com/dtech/aitrader/service/AiAnalyseService.java
@@ -1,5 +1,7 @@
 package com.dtech.aitrader.service;
 
+import com.dtech.aitrader.annotation.dto.AnnotationBundleDto;
+import com.dtech.aitrader.annotation.service.AnnotationBundleBuilder;
 import com.dtech.aitrader.data.WatchTrade;
 import com.dtech.aitrader.repository.WatchTradeRepository;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -29,20 +31,21 @@ public class AiAnalyseService {
     private final LlmGateway llmGateway;
     private final AiProviderResolver aiProviderResolver;
     private final ObjectMapper objectMapper;
+    private final AnnotationBundleBuilder annotationBundleBuilder;
 
     private static final String SYSTEM_PROMPT = """
 You are a trade-plan analyst specializing in technical analysis and risk management.
-Your role is to analyze charts, identify high-conviction setups, and propose concrete watch trades.
+Your role is to analyse the chart and propose every concrete, high-conviction watch trade that exists — both LONG and SHORT.
 
-Guidelines:
-- Be conservative: only propose trades when technical confirmation is strong
-- Reference user-drawn lines and AI-detected levels explicitly
-- Propose 0-3 trades per analysis (don't force trades if setup is weak)
-- Always calculate realistic risk:reward ratios
-- Use technical confluence: user lines + AI levels + indicator alignment
-- Consider liquidity and price level context
+Core directives:
+- BILATERAL ANALYSIS IS THE DEFAULT. If the chart presents a LONG setup AND a SHORT setup at comparable conviction, propose BOTH as separate watch trades. Do not pick a single side just because it scored marginally higher.
+- The trader's annotations (KEY_LEVEL, REJECT_ON_TOUCH, OVERTHROW_WATCH, RETEST_ENTRY, etc.) and user-drawn lines are HIGH-PRIOR signals. A trade aligned with an annotation gets confidence weight; a trade that ignores an explicit annotation must be justified.
+- The "Recent Candle Patterns" section pre-classifies the last few candles. Use those tags (bearish_engulfing, shooting_star, hammer, bullish_engulfing, doji, inside_bar) literally — if a bearish candle pattern is fired near a resistance level or annotated SHORT line, that's a primary SHORT signal.
+- Reference the source by ID in your rationale (user_line_3, h2, trendline T1, annotation KEY_LEVEL). One sentence per trade is enough.
+- Calculate realistic R:R with stops anchored to structure (not arbitrary ATR multiples) and targets at the next opposing level.
+- Cap at 4 watch trades per analysis. If fewer than 4 setups are valid, propose fewer — don't pad. If you cannot find any, return an empty array AND include a top-level "reason" string explaining what you considered and what was missing (so the trader can adjust the chart context).
 
-Output JSON strictly as specified — no markdown, no commentary.
+Output STRICT JSON — no markdown, no commentary.
 """;
 
     /**
@@ -75,8 +78,15 @@ Output JSON strictly as specified — no markdown, no commentary.
             // 2. Resolve LLM provider for user
             AiProviderResolver.ProviderConfig cfg = aiProviderResolver.resolveForUser(userId);
 
-            // 3. Build prompt
-            String userPrompt = promptBuilder.buildAnalysePrompt(symbol, tabId, layoutId, timeframe);
+            // 3. Pull trader annotations + thesis for this (user, symbol, tab); render
+            //    to a Markdown fragment the prompt builder injects up front. Annotations
+            //    (KEY_LEVEL, REJECT_ON_TOUCH, OVERTHROW_WATCH, ...) directly steer the
+            //    agent's bilateral analysis.
+            AnnotationBundleDto bundle = annotationBundleBuilder.buildForLevels(userId, symbol, tabId);
+            String annotationsFragment = annotationBundleBuilder.toPromptSection(bundle);
+
+            // 4. Build prompt
+            String userPrompt = promptBuilder.buildAnalysePrompt(symbol, tabId, layoutId, timeframe, annotationsFragment);
 
             // 4. Call LLM
             var response = llmGateway.call(cfg, SYSTEM_PROMPT, userPrompt, 2048);


### PR DESCRIPTION
Three changes to make AI Analyse stop missing the second side of a two-sided setup.

## 1. SYSTEM_PROMPT — bilateral is the default
The old prompt said "be conservative, don't force trades" — Nemotron interpreted that as "pick the best single side". New directives:
- If LONG and SHORT both look valid at comparable conviction, propose **both** as separate trades.
- Candle pattern tags are first-class signals.
- Annotations are high-prior; ignoring one needs justification.
- Cap raised 3 → 4 so a bilateral pair + context fits.
- When 0 trades emitted, require a top-level `reason` string.

## 2. Candle pattern pre-classification
New `appendCandlePatterns` section classifies the last 5 bars into:
`bearish_engulfing` · `bullish_engulfing` · `hammer / bullish_pin` · `shooting_star / bearish_pin` · `doji` · `inside_bar`.

So the agent doesn't have to spot a bearish engulfing at resistance from raw OHLC — it's labeled.

## 3. AnnotationBundleBuilder wired into AiAnalyse
`AnnotationBundleBuilder.buildForLevels(userId, symbol, tabId)` injects the trader's intent annotations (KEY_LEVEL / REJECT_ON_TOUCH / OVERTHROW_WATCH / RETEST_ENTRY / ABC_PROJECTION) and the symbol thesis. Same pattern already proven on LevelsAgent / PatternAgent.

Next AI Analyse on ALKEM should now emit the SHORT alongside the LONG if the bearish-engulfing-at-resistance setup the trader is seeing is genuine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)