### PR TITLE
fix(aitrader): readable text in annotation editable boxes

### DIFF
--- a/ui/chart-draw-app/src/aitrader/annotations/AnnotationFormModal.tsx
+++ b/ui/chart-draw-app/src/aitrader/annotations/AnnotationFormModal.tsx
@@ -244,7 +244,8 @@ const footer: React.CSSProperties = {
 };
 const input: React.CSSProperties = {
   width: '100%', padding: '6px 8px', fontSize: 13,
-  border: '1px solid #ccc', borderRadius: 4, boxSizing: 'border-box',
+  border: '1px solid #bbb', borderRadius: 4, boxSizing: 'border-box',
+  color: '#1f1f1f', background: '#fff',
 };
 const iconBtn: React.CSSProperties = {
   background: 'transparent', border: 'none', cursor: 'pointer', fontSize: 16, color: '#666',

--- a/ui/chart-draw-app/src/aitrader/annotations/AnnotationsPanel.tsx
+++ b/ui/chart-draw-app/src/aitrader/annotations/AnnotationsPanel.tsx
@@ -193,8 +193,8 @@ export default function AnnotationsPanel({ symbol, tabUuid, interval }: Props) {
 }
 
 const selectStyle: React.CSSProperties = {
-  fontSize: 12, padding: '4px 6px', border: '1px solid #ccc',
-  borderRadius: 3, background: '#fff',
+  fontSize: 12, padding: '4px 6px', border: '1px solid #bbb',
+  borderRadius: 3, background: '#fff', color: '#1f1f1f',
 };
 const btnPrimaryMini: React.CSSProperties = {
   background: '#1565c0', color: '#fff', border: 'none', borderRadius: 3,


### PR DESCRIPTION
Inline styles for inputs/selects/textareas in AnnotationsPanel and AnnotationFormModal didn't set `color` — typed text inherited the ambient document default (light gray on most browsers) and was barely visible.

Set `color: #1f1f1f`, bumped border to `#bbb`, pinned background to `#fff` so contrast holds across parent themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)