### PR TITLE
feat(aitrader): drawing-note input in toolbar — appears on drawing select

### DIFF
--- a/ui/chart-draw-app/src/aitrader/AiTraderPage.tsx
+++ b/ui/chart-draw-app/src/aitrader/AiTraderPage.tsx
@@ -6,6 +6,7 @@ import WatchTradesPanel from './WatchTradesPanel';
 import SimulatedTradesPanel from './SimulatedTradesPanel';
 import WatchlistPanel from './WatchlistPanel';
 import AnnotationsPanel from './annotations/AnnotationsPanel';
+import DrawingNoteInput from './annotations/DrawingNoteInput';
 import { getApiUrl } from '../config/api';
 import { withAuth } from '../utils/apiHelper';
 import './AiTraderPage.css';
@@ -208,6 +209,11 @@ export default function AiTraderPage() {
   const chartRef = useRef<any>(null);
   const aiShapeIdsRef = useRef<any[]>([]);
   const simTradeShapeIdsRef = useRef<any[]>([]);
+  // TV widget instance — used by DrawingNoteInput to subscribe to widget-level
+  // drawing_event. Kept in React state so the input re-mounts/wires when widget
+  // becomes ready.
+  const [tvWidget, setTvWidget] = useState<any>(null);
+  const [annotationsRefreshTick, setAnnotationsRefreshTick] = useState<number>(0);
   const tabId = getOrCreateTabId();
 
   // Single source of truth for symbol changes — bumps refreshTick so dependent panels re-fetch,
@@ -483,6 +489,14 @@ export default function AiTraderPage() {
               background: analyseLoading ? '#bbb' : '#7E57C2', color: 'white',
               cursor: analyseLoading ? 'not-allowed' : 'pointer',
             }}>{analyseLoading ? 'Analysing…' : '🔍 AI Analyse'}</button>
+          {/* On-demand drawing note input — appears only when a drawing is selected on the chart */}
+          <DrawingNoteInput
+            widget={tvWidget}
+            symbol={selectedSymbol}
+            tabUuid={tabId}
+            interval="OneHour"
+            onSaved={() => setAnnotationsRefreshTick(t => t + 1)}
+          />
         </div>
         {/* Chart */}
         <div style={{ flex: 1, minHeight: 0 }}>
@@ -490,6 +504,7 @@ export default function AiTraderPage() {
             symbol={selectedSymbol}
             timeframe="OneHour"
             tabId={tabId}
+            onWidgetReady={(w) => setTvWidget(w)}
             onChartReady={(chart) => {
               chartRef.current = chart;
               // Sync the React state when user changes symbol via TV's own search bar
@@ -539,8 +554,13 @@ export default function AiTraderPage() {
             onSelectTrade={handleSelectSimTrade}
           />
         </CollapsibleSection>
-        <CollapsibleSection title={`Annotations & thesis · ${selectedSymbol}`} defaultOpen={true}>
-          <AnnotationsPanel symbol={selectedSymbol} tabUuid={tabId} interval="OneHour" />
+        <CollapsibleSection title={`Annotations & journal · ${selectedSymbol}`} defaultOpen={true}>
+          <AnnotationsPanel
+            key={`ann-${annotationsRefreshTick}`}
+            symbol={selectedSymbol}
+            tabUuid={tabId}
+            interval="OneHour"
+          />
         </CollapsibleSection>
       </div>
       )}

--- a/ui/chart-draw-app/src/aitrader/annotations/DrawingNoteInput.tsx
+++ b/ui/chart-draw-app/src/aitrader/annotations/DrawingNoteInput.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { listAnnotations, saveAnnotation } from './api';
+
+interface Props {
+  /** TradingView widget (IChartingLibraryWidget). May be null until widget is ready. */
+  widget: any | null;
+  symbol: string;
+  tabUuid: string;
+  interval?: string;
+  /** Notify parent when a drawing-annotation save completes so it can refresh its list. */
+  onSaved?: () => void;
+}
+
+/**
+ * Inline toolbar input that activates when the trader clicks a drawing on the
+ * TradingView chart. Loads the existing free-text note for that drawing (if
+ * any), lets the trader edit, and auto-saves to /api/ai-trader/annotations on
+ * blur. Hidden when nothing is selected.
+ *
+ * Uses intent="NOTE" so plain comments don't need a typed intent. The drawing
+ * annotation panel renders a NOTE badge for these entries.
+ */
+export default function DrawingNoteInput({ widget, symbol, tabUuid, interval, onSaved }: Props) {
+  const [drawingId, setDrawingId] = useState<string | null>(null);
+  const [note, setNote] = useState<string>('');
+  const [status, setStatus] = useState<'idle' | 'loading' | 'saving' | 'saved' | 'error'>('idle');
+  const [errorMsg, setErrorMsg] = useState<string>('');
+  const initialNoteRef = useRef<string>('');
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const loadFor = useCallback(async (sourceId: string) => {
+    setStatus('loading');
+    try {
+      const list = await listAnnotations(symbol, tabUuid);
+      const existing = list.find(a => a.drawingId === sourceId);
+      const existingNote = existing?.note || '';
+      setNote(existingNote);
+      initialNoteRef.current = existingNote;
+      setStatus('idle');
+      // Focus the input shortly after render so the trader can type immediately.
+      setTimeout(() => { inputRef.current?.focus(); }, 0);
+    } catch (e: any) {
+      setStatus('error');
+      setErrorMsg(e?.message || 'load failed');
+    }
+  }, [symbol, tabUuid]);
+
+  // Subscribe to widget-level drawing_event so we know when a drawing is clicked.
+  useEffect(() => {
+    if (!widget || typeof widget.subscribe !== 'function') return;
+    const handler = (sourceId: string, event?: string) => {
+      // TV's drawing_event fires for many lifecycle phases (create, click, move,
+      // remove, properties_changed, points_changed, hide, show). We're after the
+      // user-initiated "click" — i.e. selection. Fall back to wide net if event
+      // arg is undefined on older versions.
+      if (event === undefined || event === 'click' || event === 'create') {
+        if (sourceId && sourceId !== drawingId) {
+          setDrawingId(sourceId);
+          loadFor(sourceId);
+        }
+      } else if (event === 'remove' && sourceId === drawingId) {
+        setDrawingId(null);
+        setNote('');
+      }
+    };
+    widget.subscribe('drawing_event', handler);
+    return () => {
+      try { widget.unsubscribe?.('drawing_event', handler); } catch { /* ignore */ }
+    };
+  }, [widget, drawingId, loadFor]);
+
+  async function flush() {
+    if (!drawingId) return;
+    if (note.trim() === initialNoteRef.current.trim()) return;
+    setStatus('saving');
+    try {
+      await saveAnnotation({
+        tabUuid, symbol, interval,
+        drawingId,
+        intent: 'NOTE',
+        note,
+        weight: 3,
+      });
+      initialNoteRef.current = note;
+      setStatus('saved');
+      setTimeout(() => setStatus(s => (s === 'saved' ? 'idle' : s)), 1500);
+      onSaved?.();
+    } catch (e: any) {
+      setStatus('error');
+      setErrorMsg(e?.message || 'save failed');
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Escape') {
+      // discard edits, restore initial
+      setNote(initialNoteRef.current);
+      (e.target as HTMLInputElement).blur();
+    } else if (e.key === 'Enter') {
+      (e.target as HTMLInputElement).blur(); // triggers flush
+    }
+  }
+
+  if (!drawingId) return null;
+
+  const dirty = note.trim() !== initialNoteRef.current.trim();
+  const statusLabel =
+    status === 'loading' ? 'loading…'
+    : status === 'saving' ? 'saving…'
+    : status === 'saved' ? '✓ saved'
+    : status === 'error' ? `⚠ ${errorMsg}`
+    : dirty ? 'unsaved'
+    : '';
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 6, flex: 1, minWidth: 0 }}>
+      <span style={{
+        fontSize: 10, color: '#888', fontFamily: 'monospace',
+        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: 130,
+      }} title={drawingId}>📝 {drawingId}</span>
+      <input
+        ref={inputRef}
+        value={note}
+        onChange={e => setNote(e.target.value)}
+        onBlur={flush}
+        onKeyDown={handleKeyDown}
+        placeholder="Note for this drawing — saves on blur / Enter"
+        style={{
+          flex: 1, minWidth: 100,
+          fontSize: 12, padding: '4px 8px',
+          border: '1px solid #bbb', borderRadius: 4,
+          background: '#fff', color: '#1f1f1f',
+        }}
+      />
+      <span style={{
+        fontSize: 10, color: status === 'error' ? '#c62828' : status === 'saved' ? '#2e7d32' : '#888',
+        whiteSpace: 'nowrap',
+      }}>{statusLabel}</span>
+      <button
+        onClick={() => { setDrawingId(null); setNote(''); }}
+        title="Close note input"
+        style={{
+          background: 'transparent', border: 'none', cursor: 'pointer',
+          color: '#999', fontSize: 14, padding: 0, lineHeight: 1,
+        }}>✕</button>
+    </div>
+  );
+}

--- a/ui/chart-draw-app/src/aitrader/annotations/types.ts
+++ b/ui/chart-draw-app/src/aitrader/annotations/types.ts
@@ -1,4 +1,5 @@
 export type AnnotationIntent =
+  | 'NOTE'
   | 'KEY_LEVEL'
   | 'RETEST_ENTRY'
   | 'BREAKOUT_CONFIRM'
@@ -9,6 +10,7 @@ export type AnnotationIntent =
   | 'TARGET';
 
 export const INTENT_LABELS: Record<AnnotationIntent, string> = {
+  NOTE:             'Note (free-text observation)',
   KEY_LEVEL:        'Key level (importance flag)',
   RETEST_ENTRY:     'Retest entry',
   BREAKOUT_CONFIRM: 'Breakout confirmation',
@@ -20,7 +22,7 @@ export const INTENT_LABELS: Record<AnnotationIntent, string> = {
 };
 
 export const INTENT_ORDER: AnnotationIntent[] = [
-  'KEY_LEVEL', 'RETEST_ENTRY', 'BREAKOUT_CONFIRM', 'REJECT_ON_TOUCH',
+  'NOTE', 'KEY_LEVEL', 'RETEST_ENTRY', 'BREAKOUT_CONFIRM', 'REJECT_ON_TOUCH',
   'OVERTHROW_WATCH', 'ABC_PROJECTION', 'INVALIDATION', 'TARGET',
 ];
 

--- a/ui/chart-draw-app/src/tradingview/TVChartContainer.tsx
+++ b/ui/chart-draw-app/src/tradingview/TVChartContainer.tsx
@@ -28,6 +28,12 @@ type Props = {
   symbol: string;
   timeframe: string;
   onChartReady?: (chart: any) => void;
+  /**
+   * Callback receiving the TradingView widget itself (IChartingLibraryWidget).
+   * Needed by callers who want to subscribe to widget-level events like
+   * `drawing_event` — those aren't on the chart object.
+   */
+  onWidgetReady?: (widget: any) => void;
   tradeMarkers?: TradeMarkers;
   visibleRange?: { from: number; to: number }; // unix seconds
   autoStudies?: Study[];
@@ -44,6 +50,7 @@ export default function TVChartContainer({
   symbol,
   timeframe,
   onChartReady,
+  onWidgetReady,
   tradeMarkers,
   visibleRange,
   autoStudies = [],
@@ -59,6 +66,7 @@ export default function TVChartContainer({
   // inline `onChartReady={(chart) => {...}}` would trigger a full widget remount on
   // every parent re-render — including unrelated state changes like a toast popping up.
   const onChartReadyRef = useRef(onChartReady);
+  const onWidgetReadyRef = useRef(onWidgetReady);
   const autoStudiesRef = useRef(autoStudies);
   const customIndicatorsRef = useRef(customIndicators);
   // symbol/timeframe/tabId tracked in refs so the saveLoadAdapter context closure
@@ -67,6 +75,7 @@ export default function TVChartContainer({
   const timeframeRef = useRef(timeframe);
   const tabIdRef = useRef(tabId);
   useEffect(() => { onChartReadyRef.current = onChartReady; }, [onChartReady]);
+  useEffect(() => { onWidgetReadyRef.current = onWidgetReady; }, [onWidgetReady]);
   useEffect(() => { autoStudiesRef.current = autoStudies; }, [autoStudies]);
   useEffect(() => { customIndicatorsRef.current = customIndicators; }, [customIndicators]);
   useEffect(() => { symbolRef.current = symbol; }, [symbol]);
@@ -127,6 +136,9 @@ export default function TVChartContainer({
 
     const tvWidget = new TradingView.widget(widgetOptions);
     widgetRef.current = tvWidget;
+    // Fire onWidgetReady synchronously so callers can subscribe to widget-level
+    // events (drawing_event etc.) before onChartReady fires asynchronously.
+    try { onWidgetReadyRef.current?.(tvWidget); } catch (e) { console.warn('onWidgetReady threw', e); }
 
     tvWidget.onChartReady(() => {
       try {


### PR DESCRIPTION
When the trader clicks a drawing on the TradingView chart, an input appears in the toolbar (next to AI Analyse), auto-loads the existing note for that drawing, focuses, and saves on blur / Enter. Escape discards. ✕ closes.

Persisted as an annotation row with `intent="NOTE"` so it shows up in the annotations list as a NOTE-badged entry — no intent params, no weight typing.

## Wiring
- `TVChartContainer` gets new optional `onWidgetReady(widget)` callback. Needed because `drawing_event` is on the widget, not the chart.
- `DrawingNoteInput` (new) subscribes to `widget.subscribe('drawing_event')`, captures the clicked drawing's id, loads its existing annotation note, lets the trader edit, saves on blur/Enter.
- `AiTraderPage` holds widget in state so the input re-wires when widget is ready, and renders the input in the toolbar.
- Section header in the right column renamed: `Annotations & thesis` → `Annotations & journal` (matches the journal model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)