### PR TITLE
AI Trader v2 — Phase 8: per-user memsys OAuth + Kite onboarding + lean bundles

### DIFF
--- a/src/main/java/com/dtech/aitrader/data/PlanGroup.java
+++ b/src/main/java/com/dtech/aitrader/data/PlanGroup.java
@@ -1,0 +1,126 @@
+package com.dtech.aitrader.data;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * v2 plan_group — a single market structure that may resolve into multiple mutually-exclusive
+ * branches. One row per scan-time hypothesis on a symbol+timeframe.
+ *
+ * Companion to the memsys "trade memory" (one memsys memory per plan_group, linked via
+ * {@link #memsysMemoryId}). Postgres is source of truth for operational state; memsys is source
+ * of truth for content and threaded discussion.
+ *
+ * See "AI Trader v2 — Plan Groups & Branches Schema [v1.1]" memsys memory for the design rationale,
+ * lifecycle rules, and trigger cascade semantics.
+ */
+@Entity
+@Table(
+    name = "plan_group",
+    indexes = {
+        @Index(name = "ix_plan_group_user_symbol_state", columnList = "user_id, symbol, state"),
+        @Index(name = "ix_plan_group_state_valid_until", columnList = "state, valid_until")
+    }
+)
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlanGroup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 32)
+    private String symbol;
+
+    /** Timeframe at scan time — "1D", "1W", "1H", etc. */
+    @Column(nullable = false, length = 16)
+    private String timeframe;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private PlanGroupState state;
+
+    /** Free-form Agent 1 prose: what's the structural reading? */
+    @Column(name = "underlying_hypothesis", columnDefinition = "TEXT")
+    private String underlyingHypothesis;
+
+    /** Free-form Agent 1 prose: how was the structure validated against pivots/labels/playbook? */
+    @Column(name = "structural_validation", columnDefinition = "TEXT")
+    private String structuralValidation;
+
+    /** JSON array of drawing ids that contributed to this plan_group, serialized as text. */
+    @Column(name = "source_drawing_ids", columnDefinition = "TEXT")
+    private String sourceDrawingIdsJson;
+
+    /** JSON array of pivot label ids referenced by Agent 1, serialized as text. */
+    @Column(name = "source_label_ids", columnDefinition = "TEXT")
+    private String sourceLabelIdsJson;
+
+    /** JSON array of symbol_journal_note ids referenced by Agent 1, serialized as text. */
+    @Column(name = "source_journal_note_ids", columnDefinition = "TEXT")
+    private String sourceJournalNoteIdsJson;
+
+    /** JSON array of playbook rule ids (memsys memory uuids) the agent cited, serialized as text. */
+    @Column(name = "playbook_rules_applied", columnDefinition = "TEXT")
+    private String playbookRulesAppliedJson;
+
+    /** Shared decision zone — the price band where the hypothesis resolves one way or the other. */
+    @Column(name = "decision_zone_low", precision = 12, scale = 2)
+    private BigDecimal decisionZoneLow;
+
+    @Column(name = "decision_zone_high", precision = 12, scale = 2)
+    private BigDecimal decisionZoneHigh;
+
+    @Column(name = "decision_zone_rationale", columnDefinition = "TEXT")
+    private String decisionZoneRationale;
+
+    @Column(name = "valid_until")
+    private LocalDateTime validUntil;
+
+    /** Self-referential nullable FK — points at the older plan_group this one replaced. */
+    @Column(name = "supersedes_group_id")
+    private Long supersedesGroupId;
+
+    @Column(name = "scan_summary", columnDefinition = "TEXT")
+    private String scanSummary;
+
+    /** Prompt/agent version that produced this group (e.g. "v1.1"). */
+    @Column(name = "agent_version", length = 16)
+    private String agentVersion;
+
+    /** Verbatim Agent 1 output JSON for audit/replay. */
+    @Column(name = "raw_agent_output", columnDefinition = "MEDIUMTEXT")
+    private String rawAgentOutput;
+
+    /** memsys companion memory uuid (set after orchestrator writes the trade memory). */
+    @Column(name = "memsys_memory_id", length = 64)
+    private String memsysMemoryId;
+
+    @PrePersist
+    void onCreate() {
+        LocalDateTime now = LocalDateTime.now();
+        if (createdAt == null) createdAt = now;
+        updatedAt = now;
+        if (state == null) state = PlanGroupState.WATCHING;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dtech/aitrader/data/PlanGroupState.java
+++ b/src/main/java/com/dtech/aitrader/data/PlanGroupState.java
@@ -1,0 +1,23 @@
+package com.dtech.aitrader.data;
+
+/**
+ * Lifecycle states for a v2 plan_group.
+ *
+ * <ul>
+ *   <li>{@link #WATCHING} — at least one branch monitored by the deterministic trigger.</li>
+ *   <li>{@link #TRIGGERED} — one branch fired; siblings auto-invalidated; group locked.</li>
+ *   <li>{@link #EXPIRED} — {@code valid_until} elapsed without any trigger.</li>
+ *   <li>{@link #INVALIDATED} — source structure broken; all branches die.</li>
+ *   <li>{@link #SUPERSEDED} — a newer plan_group with a materially different hypothesis took over.</li>
+ * </ul>
+ *
+ * State transitions are orchestrated by the v2 orchestrator service and mirrored as
+ * tag changes on the companion memsys trade memory (see AI Trader v2 — Plan Groups & Branches Schema v1.1).
+ */
+public enum PlanGroupState {
+    WATCHING,
+    TRIGGERED,
+    EXPIRED,
+    INVALIDATED,
+    SUPERSEDED;
+}

--- a/src/main/java/com/dtech/aitrader/data/WatchTrade.java
+++ b/src/main/java/com/dtech/aitrader/data/WatchTrade.java
@@ -71,4 +71,29 @@ public class WatchTrade {
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
+
+    // ── v2 branch fields ─────────────────────────────────────────────
+    // Nullable so existing watch_trade rows (and any new ones still using the v1
+    // flat-list path) continue to function. A row becomes a "v2 branch" when
+    // plan_group_id is set — the orchestrator dual-writes plan_group + branches
+    // atomically at scan time.
+
+    /** FK to plan_group.id when this row is one branch of a multi-hypothesis structure. */
+    @Column(name = "plan_group_id")
+    private Long planGroupId;
+
+    /** Short label given by the agent to identify the branch (e.g. "long-breakout", "short-truncation"). */
+    @Column(name = "branch_label", length = 64)
+    private String branchLabel;
+
+    /** JSON array (text-serialized) of sibling watch_trade ids that should die when this one triggers. */
+    @Column(name = "sibling_kill_branch_ids", columnDefinition = "TEXT")
+    private String siblingKillBranchIdsJson;
+
+    /** Mirrored from the parent plan_group for fast indexable range queries by the trigger. */
+    @Column(name = "decision_zone_low", precision = 12, scale = 2)
+    private BigDecimal decisionZoneLow;
+
+    @Column(name = "decision_zone_high", precision = 12, scale = 2)
+    private BigDecimal decisionZoneHigh;
 }

--- a/src/main/java/com/dtech/aitrader/repository/PlanGroupRepository.java
+++ b/src/main/java/com/dtech/aitrader/repository/PlanGroupRepository.java
@@ -1,0 +1,22 @@
+package com.dtech.aitrader.repository;
+
+import com.dtech.aitrader.data.PlanGroup;
+import com.dtech.aitrader.data.PlanGroupState;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface PlanGroupRepository extends JpaRepository<PlanGroup, Long> {
+
+    /** Active plan_groups for a (user, symbol) — primary lookup during a scan. */
+    List<PlanGroup> findByUserIdAndSymbolAndState(Long userId, String symbol, PlanGroupState state);
+
+    /** Used by the hourly sweeper to expire stale WATCHING groups. */
+    List<PlanGroup> findByStateAndValidUntilBefore(PlanGroupState state, LocalDateTime cutoff);
+
+    /** All currently WATCHING groups for a user (across symbols) — used by morning review aggregation. */
+    List<PlanGroup> findByUserIdAndStateOrderByUpdatedAtDesc(Long userId, PlanGroupState state);
+}

--- a/src/main/java/com/dtech/aitrader/service/LevelsAgentService.java
+++ b/src/main/java/com/dtech/aitrader/service/LevelsAgentService.java
@@ -168,7 +168,7 @@ Use ISO-8601 UTC timestamps with the trailing 'Z'. Use absolute INR prices.
      *   - JS-style // comments and trailing commas
      * Falls back to the original (trimmed) text if no braces found.
      */
-    static String extractJsonObject(String raw) {
+    public static String extractJsonObject(String raw) {
         if (raw == null) return "";
         String s = raw.trim();
         // Strip code fences if present

--- a/src/main/java/com/dtech/aitrader/v2/agent/Agent1Client.java
+++ b/src/main/java/com/dtech/aitrader/v2/agent/Agent1Client.java
@@ -3,6 +3,8 @@ package com.dtech.aitrader.v2.agent;
 import com.dtech.aitrader.service.AiProviderResolver;
 import com.dtech.aitrader.service.LevelsAgentService;
 import com.dtech.aitrader.service.LlmGateway;
+import com.dtech.kitecon.service.copilot.UserAiProviderService;
+import com.dtech.kitecon.data.copilot.UserAiProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 
 /**
  * Single-shot completion call to Agent 1 (Strategic Planner). Loads the v1.1 system prompt
@@ -34,6 +37,7 @@ import java.nio.charset.StandardCharsets;
 public class Agent1Client {
 
     private final AiProviderResolver providerResolver;
+    private final UserAiProviderService userAiProviderService;
     private final LlmGateway llmGateway;
     private final ObjectMapper mapper;
 
@@ -42,6 +46,18 @@ public class Agent1Client {
 
     @Value("${agent1.max-tokens:4096}")
     private int maxTokens;
+
+    /**
+     * Override API key for Agent 1 (typically Anthropic). When set, Agent 1 uses this key + base URL
+     * instead of the user's resolved provider. Empty → fall back to user's provider (likely fails if
+     * user's provider doesn't speak the agent1.model — that's the routing the trader will see in dev).
+     */
+    @Value("${agent1.api-key:}")
+    private String agent1ApiKey;
+
+    /** Base URL for Agent 1 provider. Default points at Anthropic. */
+    @Value("${agent1.base-url:https://api.anthropic.com/v1}")
+    private String agent1BaseUrl;
 
     private volatile String cachedSystemPrompt;
 
@@ -54,11 +70,42 @@ public class Agent1Client {
     public Agent1Invocation invoke(Long userId, String userMessage) {
         String systemPrompt = loadSystemPrompt();
         AiProviderResolver.ProviderConfig baseCfg = providerResolver.resolveForUser(userId);
+
+        // Agent 1 has its own provider routing so we don't send Claude models to an
+        // OpenAI-compatible endpoint (like NVIDIA Nemotron) the user might have set as
+        // their default. Resolution order:
+        //   1. agent1.api-key property — explicit override
+        //   2. The user's saved Anthropic provider row (active or not) from user_ai_provider
+        //   3. Fall back to the user's resolved active provider (will likely 404 if model
+        //      doesn't match — clear signal to configure)
+        String apiKey;
+        String baseUrl;
+        if (agent1ApiKey != null && !agent1ApiKey.isBlank()) {
+            apiKey = agent1ApiKey;
+            baseUrl = agent1BaseUrl;
+        } else {
+            Optional<UserAiProvider> anthropicProvider =
+                    userAiProviderService.findByUserIdAndBaseUrlContains(userId, "anthropic.com");
+            Optional<String> anthropicKey = anthropicProvider.flatMap(userAiProviderService::getDecryptedApiKey);
+            if (anthropicProvider.isPresent() && anthropicKey.isPresent()) {
+                apiKey = anthropicKey.get();
+                baseUrl = anthropicProvider.get().getBaseUrl();
+                log.info("[agent1] using user's saved Anthropic provider (id={}, active={})",
+                        anthropicProvider.get().getId(), anthropicProvider.get().isActive());
+            } else {
+                apiKey = baseCfg.apiKey();
+                baseUrl = baseCfg.baseUrl();
+                log.warn("[agent1] no Anthropic provider configured for user {} — falling back to active provider {}",
+                        userId, baseUrl);
+            }
+        }
+        boolean isAnthropic = baseUrl != null && baseUrl.contains("anthropic.com");
+
         AiProviderResolver.ProviderConfig agent1Cfg = new AiProviderResolver.ProviderConfig(
-                baseCfg.apiKey(),
+                apiKey,
                 agent1Model,
-                baseCfg.baseUrl(),
-                baseCfg.isAnthropic(),
+                baseUrl,
+                isAnthropic,
                 baseCfg.isLocal()
         );
 

--- a/src/main/java/com/dtech/aitrader/v2/agent/Agent1Client.java
+++ b/src/main/java/com/dtech/aitrader/v2/agent/Agent1Client.java
@@ -1,0 +1,119 @@
+package com.dtech.aitrader.v2.agent;
+
+import com.dtech.aitrader.service.AiProviderResolver;
+import com.dtech.aitrader.service.LevelsAgentService;
+import com.dtech.aitrader.service.LlmGateway;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Single-shot completion call to Agent 1 (Strategic Planner). Loads the v1.1 system prompt
+ * from {@code classpath:prompts/agent1_v1_1.txt}, hands the user-message bundle to
+ * {@link LlmGateway}, parses + schema-validates the returned JSON.
+ *
+ * Provider selection:
+ *  - {@code agent1.model} property pins the Agent 1 model (defaults to Sonnet 4.6).
+ *  - The user's own provider config (key + base_url) is still resolved via
+ *    {@link AiProviderResolver}, but the resolved model is overridden for the call so
+ *    Agent 1 always lands on its tier — see "AI Trader v2 Tiered Model Strategy" in the
+ *    v1.2 plan.
+ *
+ * Schema fail → one retry with appended instruction → fail-soft (returns null and logs).
+ * The orchestrator decides whether to skip the scan or write an audit memory.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class Agent1Client {
+
+    private final AiProviderResolver providerResolver;
+    private final LlmGateway llmGateway;
+    private final ObjectMapper mapper;
+
+    @Value("${agent1.model:claude-sonnet-4-5-20250929}")
+    private String agent1Model;
+
+    @Value("${agent1.max-tokens:4096}")
+    private int maxTokens;
+
+    private volatile String cachedSystemPrompt;
+
+    /**
+     * Invoke Agent 1 for one (user, symbol). Returns the parsed output, or null on schema fail.
+     *
+     * @param userId       caller — drives provider config selection (api key + base url)
+     * @param userMessage  the rendered bundle string built by the orchestrator
+     */
+    public Agent1Invocation invoke(Long userId, String userMessage) {
+        String systemPrompt = loadSystemPrompt();
+        AiProviderResolver.ProviderConfig baseCfg = providerResolver.resolveForUser(userId);
+        AiProviderResolver.ProviderConfig agent1Cfg = new AiProviderResolver.ProviderConfig(
+                baseCfg.apiKey(),
+                agent1Model,
+                baseCfg.baseUrl(),
+                baseCfg.isAnthropic(),
+                baseCfg.isLocal()
+        );
+
+        log.info("[agent1] invoking model={} for userId={}", agent1Cfg.model(), userId);
+        long t0 = System.currentTimeMillis();
+        LlmGateway.LlmResponse response = llmGateway.call(agent1Cfg, systemPrompt, userMessage, maxTokens);
+        long elapsedMs = System.currentTimeMillis() - t0;
+
+        Agent1Output parsed = tryParse(response.text());
+        if (parsed == null) {
+            // One retry with a corrective prompt addendum.
+            String retryMessage = userMessage
+                    + "\n\n---\nYour previous response was malformed JSON. Return only the JSON object — no markdown, no commentary.";
+            log.warn("[agent1] schema fail; retrying with corrective addendum");
+            response = llmGateway.call(agent1Cfg, systemPrompt, retryMessage, maxTokens);
+            parsed = tryParse(response.text());
+        }
+
+        log.info("[agent1] done model={} tokens_in={} tokens_out={} cost=${} elapsed={}ms parsed={}",
+                response.modelUsed(), response.inputTokens(), response.outputTokens(),
+                response.costUsd(), elapsedMs, parsed != null);
+
+        return new Agent1Invocation(parsed, response, elapsedMs);
+    }
+
+    private Agent1Output tryParse(String rawText) {
+        try {
+            String jsonText = LevelsAgentService.extractJsonObject(rawText);
+            return mapper.readValue(jsonText, Agent1Output.class);
+        } catch (Exception e) {
+            log.warn("[agent1] failed to parse Agent 1 response: {}; first 500 chars: {}",
+                    e.getMessage(),
+                    rawText == null ? "(null)" : rawText.substring(0, Math.min(500, rawText.length())));
+            return null;
+        }
+    }
+
+    private String loadSystemPrompt() {
+        if (cachedSystemPrompt != null) return cachedSystemPrompt;
+        synchronized (this) {
+            if (cachedSystemPrompt != null) return cachedSystemPrompt;
+            try {
+                var resource = new ClassPathResource("prompts/agent1_v1_1.txt");
+                try (var is = resource.getInputStream()) {
+                    cachedSystemPrompt = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                }
+                log.info("[agent1] loaded system prompt ({} chars)", cachedSystemPrompt.length());
+                return cachedSystemPrompt;
+            } catch (IOException e) {
+                throw new IllegalStateException("agent1_v1_1.txt missing from classpath:prompts/", e);
+            }
+        }
+    }
+
+    public record Agent1Invocation(Agent1Output output, LlmGateway.LlmResponse response, long elapsedMs) {
+        public boolean ok() { return output != null; }
+    }
+}

--- a/src/main/java/com/dtech/aitrader/v2/agent/Agent1Output.java
+++ b/src/main/java/com/dtech/aitrader/v2/agent/Agent1Output.java
@@ -1,0 +1,89 @@
+package com.dtech.aitrader.v2.agent;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/** Top-level Agent 1 JSON response. Tolerant of unknown fields so prompt versions can evolve. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Agent1Output {
+    private String symbol;
+    private String scan_timestamp;
+    private List<PlanGroupSpec> plan_groups;
+    private List<FlagSpec> flags;
+    private String scan_summary;
+    private String no_plan_reason;
+
+    @Data @Builder @NoArgsConstructor @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class PlanGroupSpec {
+        private String id;
+        /** CREATE | UPDATE | SUPERSEDE | RETIRE */
+        private String action;
+        private String supersedes_group_id;
+        private String underlying_hypothesis;
+        private String structural_validation;
+        private List<String> source_drawing_ids;
+        private List<String> source_label_ids;
+        private List<String> source_journal_note_ids;
+        private List<String> playbook_rules_applied;
+        private List<String> applied_user_comment_ids;
+        private DecisionZoneSpec decision_zone;
+        private String valid_until;
+        private List<BranchSpec> branches;
+    }
+
+    @Data @Builder @NoArgsConstructor @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class DecisionZoneSpec {
+        private Double low;
+        private Double high;
+        private String rationale;
+    }
+
+    @Data @Builder @NoArgsConstructor @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class BranchSpec {
+        private String id;
+        private String label;
+        /** LONG | SHORT */
+        private String direction;
+        private List<Double> entry_zone;
+        private String trigger_condition;
+        private List<String> required_pattern;
+        private Double stop_loss;
+        private List<Double> targets;
+        private Double invalidation_level;
+        private String invalidation_rule;
+        private List<String> sibling_kill_branches;
+        private Double confidence;
+        private String reasoning;
+    }
+
+    @Data @Builder @NoArgsConstructor @AllArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class FlagSpec {
+        private String id;
+        /** INFO | WARNING | BLOCKING */
+        private String severity;
+        private String category;
+        private String title;
+        private String details;
+        private String affects_plan_group_id;
+        /** array of strings OR string "whole_group" OR null — parsed as JsonNode to tolerate either. */
+        private JsonNode affects_branch_ids;
+        private List<String> source_drawing_ids;
+        private List<String> source_label_ids;
+        private List<String> related_playbook_rule_ids;
+        private String suggested_resolution;
+    }
+}

--- a/src/main/java/com/dtech/aitrader/v2/batch/NightlyBundleDumpService.java
+++ b/src/main/java/com/dtech/aitrader/v2/batch/NightlyBundleDumpService.java
@@ -1,0 +1,192 @@
+package com.dtech.aitrader.v2.batch;
+
+import com.dtech.aitrader.v2.scan.Agent1BundleBuilder;
+import com.dtech.aitrader.v2.scan.ScanContext;
+import com.dtech.aitrader.v2.scan.ScanContextWriter;
+import com.dtech.kitecon.repository.IndexSymbolRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Nightly batch that builds Agent 1 input bundles for every FNO symbol and posts each one
+ * to memsys as an {@code ai-trader-scan-context} memory.
+ *
+ * <p>It does <strong>NOT</strong> call Agent 1 here — by design. The expensive planning step
+ * runs on the user's Max-plan capacity via a claude.ai scheduled routine that reads tonight's
+ * bundles from memsys and emits trade memories back. The backend's job is bundle preparation
+ * + memsys persistence, free of per-token LLM cost.
+ *
+ * <p>Config (all overridable per env via application.properties):
+ * <ul>
+ *   <li>{@code agent1.batch.enabled} — master switch (default false; flip true once memsys auth is in place)</li>
+ *   <li>{@code agent1.batch.cron} — Spring cron expression, IST timezone (default "0 0 22 * * MON-FRI")</li>
+ *   <li>{@code agent1.batch.user-id} — owner of the scan (default 1)</li>
+ *   <li>{@code agent1.batch.timeframe} — analysis timeframe (default "OneHour")</li>
+ *   <li>{@code agent1.batch.index} — universe to scan (default "FNO"; column in index_symbol table)</li>
+ *   <li>{@code agent1.batch.skip-empty-context} — drop symbols with no user drawings/annotations/journal
+ *       (default true — saves routine tokens for symbols Agent 1 will refuse anyway)</li>
+ *   <li>{@code agent1.batch.max-symbols} — safety cap on number of writes per fire (default 500)</li>
+ * </ul>
+ *
+ * Manual fire: see {@link com.dtech.aitrader.v2.web.AiTraderV2Controller}'s
+ * {@code POST /api/ai-trader-v2/batch/run} endpoint.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NightlyBundleDumpService {
+
+    private static final String AGENT_VERSION = "v1.1";
+
+    private final Agent1BundleBuilder bundleBuilder;
+    private final ScanContextWriter scanContextWriter;
+    private final IndexSymbolRepository indexSymbolRepository;
+
+    @Value("${agent1.batch.enabled:false}")
+    private boolean enabled;
+
+    @Value("${agent1.batch.user-id:1}")
+    private Long batchUserId;
+
+    @Value("${agent1.batch.timeframe:OneHour}")
+    private String batchTimeframe;
+
+    @Value("${agent1.batch.index:FNO}")
+    private String batchIndex;
+
+    @Value("${agent1.batch.skip-empty-context:true}")
+    private boolean skipEmptyContext;
+
+    @Value("${agent1.batch.max-symbols:500}")
+    private int maxSymbols;
+
+    /**
+     * Scheduled fire. Cron is read from {@code agent1.batch.cron} (default 22:00 IST weekdays).
+     * Guarded by {@code agent1.batch.enabled} — the cron itself fires every cycle, but the
+     * method exits immediately when disabled. This keeps the bean Spring-managed and avoids
+     * the conditional-scheduling boilerplate.
+     */
+    @Scheduled(cron = "${agent1.batch.cron:0 0 22 * * MON-FRI}", zone = "Asia/Kolkata")
+    public void scheduledRun() {
+        if (!enabled) {
+            log.debug("[v2-batch] skipped: agent1.batch.enabled=false");
+            return;
+        }
+        run("scheduled");
+    }
+
+    /** Manual fire entrypoint — invoked by the controller's POST /batch/run endpoint. */
+    public Summary runManual() {
+        return run("manual");
+    }
+
+    private Summary run(String trigger) {
+        Instant start = Instant.now();
+        log.info("[v2-batch] start trigger={} userId={} index={} timeframe={} skipEmpty={}",
+                trigger, batchUserId, batchIndex, batchTimeframe, skipEmptyContext);
+
+        List<String> symbols;
+        try {
+            symbols = indexSymbolRepository.findAllSymbolsByIndexName(batchIndex);
+        } catch (Exception e) {
+            log.error("[v2-batch] failed to fetch symbol list for index '{}': {}", batchIndex, e.getMessage(), e);
+            return new Summary(trigger, 0, 0, 0, 0, Duration.between(start, Instant.now()).toMillis(),
+                    "symbol-list-fetch-failed: " + e.getMessage());
+        }
+
+        if (symbols == null || symbols.isEmpty()) {
+            log.warn("[v2-batch] symbol list for index '{}' is empty — nothing to do", batchIndex);
+            return new Summary(trigger, 0, 0, 0, 0, Duration.between(start, Instant.now()).toMillis(),
+                    "empty-symbol-list");
+        }
+
+        int cap = Math.min(symbols.size(), maxSymbols);
+        if (cap < symbols.size()) {
+            log.warn("[v2-batch] capping {} → {} symbols (agent1.batch.max-symbols={})",
+                    symbols.size(), cap, maxSymbols);
+        }
+
+        AtomicInteger built = new AtomicInteger();
+        AtomicInteger written = new AtomicInteger();
+        AtomicInteger skipped = new AtomicInteger();
+        AtomicInteger failed = new AtomicInteger();
+
+        for (int i = 0; i < cap; i++) {
+            String symbol = symbols.get(i);
+            try {
+                Agent1BundleBuilder.Built b = bundleBuilder.build(batchUserId, symbol, batchTimeframe, null, AGENT_VERSION);
+                ScanContext ctx = b.scanContext();
+                built.incrementAndGet();
+
+                if (skipEmptyContext && isEmptyContext(ctx)) {
+                    skipped.incrementAndGet();
+                    continue;
+                }
+
+                String memoryId = scanContextWriter.write(ctx);
+                if (memoryId != null) {
+                    written.incrementAndGet();
+                } else {
+                    failed.incrementAndGet();
+                }
+            } catch (Exception e) {
+                failed.incrementAndGet();
+                log.warn("[v2-batch] symbol {} failed: {}", symbol, e.getMessage());
+            }
+
+            // Light pacing so we don't slam the memsys MCP — 100ms between writes ≈ 10 writes/sec
+            if (written.get() > 0 && written.get() % 10 == 0) {
+                try { Thread.sleep(100); } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    log.warn("[v2-batch] interrupted at index {}/{} — exiting early", i, cap);
+                    break;
+                }
+            }
+        }
+
+        long elapsedMs = Duration.between(start, Instant.now()).toMillis();
+        Summary s = new Summary(trigger, built.get(), written.get(), skipped.get(), failed.get(), elapsedMs, null);
+        log.info("[v2-batch] done trigger={} built={} written={} skipped={} failed={} elapsed={}ms",
+                trigger, s.built, s.written, s.skipped, s.failed, elapsedMs);
+        return s;
+    }
+
+    /**
+     * "Empty context" means the trader hasn't given Agent 1 anything to interpret on this symbol —
+     * no drawings, no annotations, no journal notes, no existing plan groups, no candle patterns
+     * worth flagging. Agent 1 will emit only a "no user structure declared" INFO flag in this case,
+     * so skipping these symbols saves routine tokens without losing actionable output.
+     */
+    private boolean isEmptyContext(ScanContext ctx) {
+        if (ctx == null) return true;
+        boolean noAnnotations = isNullOrEmpty(ctx.getAnnotations());
+        boolean noJournal = isNullOrEmpty(ctx.getJournalNotes());
+        boolean noDrawings = isNullOrEmpty(ctx.getDrawings());
+        boolean noPivotLabels = isNullOrEmpty(ctx.getPivotLabels());
+        boolean noExistingGroups = isNullOrEmpty(ctx.getExistingPlanGroups());
+        return noAnnotations && noJournal && noDrawings && noPivotLabels && noExistingGroups;
+    }
+
+    private static boolean isNullOrEmpty(java.util.Collection<?> c) {
+        return c == null || c.isEmpty();
+    }
+
+    /** Returned by both scheduled + manual fire. Trigger is "scheduled" or "manual". */
+    public record Summary(
+            String trigger,
+            int built,
+            int written,
+            int skipped,
+            int failed,
+            long elapsedMs,
+            String error
+    ) {}
+}

--- a/src/main/java/com/dtech/aitrader/v2/kite/KiteDataClient.java
+++ b/src/main/java/com/dtech/aitrader/v2/kite/KiteDataClient.java
@@ -1,0 +1,60 @@
+package com.dtech.aitrader.v2.kite;
+
+import com.zerodhatech.models.HistoricalData;
+import com.zerodhatech.models.Holding;
+import com.zerodhatech.models.Position;
+import com.zerodhatech.models.Order;
+import com.zerodhatech.models.Margin;
+import com.zerodhatech.models.Quote;
+import com.zerodhatech.models.LTPQuote;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * READ-ONLY view over Kite for AI Trader v2.
+ *
+ * Per the 2026-05-18 correction (memsys memory 1add3fb3-…) order placement
+ * is NOT routed through this client. Live orders continue to use the existing
+ * algotrade OrderService path. This client exposes only the read methods
+ * Agent 1's input bundle and the deterministic trigger need.
+ *
+ * Implementation wraps the existing KiteConnectPool (per-user KiteConnect
+ * instances with current access tokens) — the same path KiteAutoLoginService
+ * uses.
+ */
+public interface KiteDataClient {
+
+    /** Latest LTP + bid/ask depth for one or more exchange-prefixed instruments. */
+    Map<String, Quote> getQuote(Long userId, List<String> instruments) throws KiteDataException;
+
+    /** Quick LTP-only fetch — cheaper than full quote when only the price is needed. */
+    Map<String, LTPQuote> getLtp(Long userId, List<String> instruments) throws KiteDataException;
+
+    /**
+     * Historical OHLC bars for one instrument. Interval values match Kite's API
+     * ("minute", "3minute", "5minute", "15minute", "30minute", "60minute", "day", "week", "month").
+     */
+    HistoricalData getHistoricalData(
+            Long userId,
+            long instrumentToken,
+            LocalDate from,
+            LocalDate to,
+            String interval,
+            boolean continuous,
+            boolean oi
+    ) throws KiteDataException;
+
+    /** Current holdings. Used by morning chat review for portfolio context. */
+    List<Holding> getHoldings(Long userId) throws KiteDataException;
+
+    /** Current intraday + overnight positions. */
+    Map<String, List<Position>> getPositions(Long userId) throws KiteDataException;
+
+    /** Today's orders (placed, executed, cancelled). */
+    List<Order> getOrders(Long userId) throws KiteDataException;
+
+    /** Margin balances per segment. */
+    Map<String, Margin> getMargins(Long userId) throws KiteDataException;
+}

--- a/src/main/java/com/dtech/aitrader/v2/kite/KiteDataClientImpl.java
+++ b/src/main/java/com/dtech/aitrader/v2/kite/KiteDataClientImpl.java
@@ -1,0 +1,142 @@
+package com.dtech.aitrader.v2.kite;
+
+import com.dtech.kitecon.config.KiteConnectPool;
+import com.zerodhatech.kiteconnect.KiteConnect;
+import com.zerodhatech.kiteconnect.kitehttp.exceptions.KiteException;
+import com.zerodhatech.models.HistoricalData;
+import com.zerodhatech.models.Holding;
+import com.zerodhatech.models.LTPQuote;
+import com.zerodhatech.models.Margin;
+import com.zerodhatech.models.Order;
+import com.zerodhatech.models.Position;
+import com.zerodhatech.models.Quote;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Read-only Kite client used by the AI Trader v2 orchestrator and trigger.
+ *
+ * Backed by the existing {@link KiteConnectPool} — uses the primary authenticated
+ * client for state queries and the round-robin historical client for OHLC fetches
+ * (to spread Kite's per-app rate-limit across users when multi-tenant).
+ *
+ * Order placement is intentionally NOT exposed here. Live orders continue to flow
+ * through the existing algotrade OrderService path per 2026-05-18 design correction.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KiteDataClientImpl implements KiteDataClient {
+
+    /**
+     * Kite's historical endpoint expects "YYYY-MM-DD HH:mm:ss". For daily/weekly we send
+     * midnight; intra-day fetches will be added when the orchestrator needs them.
+     */
+    private static final DateTimeFormatter KITE_HISTORICAL_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
+    private final KiteConnectPool pool;
+
+    @Override
+    public Map<String, Quote> getQuote(Long userId, List<String> instruments) {
+        try {
+            KiteConnect kc = primary();
+            String[] arr = instruments.toArray(new String[0]);
+            return kc.getQuote(arr);
+        } catch (KiteException | java.io.IOException e) {
+            throw new KiteDataException("getQuote failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Map<String, LTPQuote> getLtp(Long userId, List<String> instruments) {
+        try {
+            KiteConnect kc = primary();
+            String[] arr = instruments.toArray(new String[0]);
+            return kc.getLTP(arr);
+        } catch (KiteException | java.io.IOException e) {
+            throw new KiteDataException("getLtp failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public HistoricalData getHistoricalData(Long userId,
+                                            long instrumentToken,
+                                            LocalDate from,
+                                            LocalDate to,
+                                            String interval,
+                                            boolean continuous,
+                                            boolean oi) {
+        try {
+            KiteConnect kc = historical();
+            // SDK uses java.util.Date — wrap LocalDate at start-of-day.
+            java.util.Date fromDate = java.sql.Timestamp.valueOf(from.atStartOfDay());
+            java.util.Date toDate = java.sql.Timestamp.valueOf(to.atTime(23, 59, 59));
+            return kc.getHistoricalData(fromDate, toDate, String.valueOf(instrumentToken), interval, continuous, oi);
+        } catch (KiteException | java.io.IOException e) {
+            throw new KiteDataException("getHistoricalData failed for " + instrumentToken + ": " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<Holding> getHoldings(Long userId) {
+        try {
+            return primary().getHoldings();
+        } catch (KiteException | java.io.IOException e) {
+            throw new KiteDataException("getHoldings failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Map<String, List<Position>> getPositions(Long userId) {
+        try {
+            // KiteConnect 4.x getPositions() returns Map<String, List<Position>>
+            // with keys "day" and "net" — surface as-is.
+            return primary().getPositions();
+        } catch (KiteException | java.io.IOException e) {
+            throw new KiteDataException("getPositions failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public List<Order> getOrders(Long userId) {
+        try {
+            return primary().getOrders();
+        } catch (KiteException | java.io.IOException e) {
+            throw new KiteDataException("getOrders failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public Map<String, Margin> getMargins(Long userId) {
+        try {
+            return primary().getMargins();
+        } catch (KiteException | java.io.IOException e) {
+            throw new KiteDataException("getMargins failed: " + e.getMessage(), e);
+        }
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    private KiteConnect primary() {
+        KiteConnect kc = pool.getPrimaryClient();
+        if (kc == null) {
+            throw new KiteDataException("no primary KiteConnect client available — login required");
+        }
+        return kc;
+    }
+
+    private KiteConnect historical() {
+        KiteConnect kc = pool.getNextClientForHistorical();
+        if (kc == null) {
+            throw new KiteDataException("no authenticated KiteConnect client available for historical data");
+        }
+        return kc;
+    }
+}

--- a/src/main/java/com/dtech/aitrader/v2/kite/KiteDataException.java
+++ b/src/main/java/com/dtech/aitrader/v2/kite/KiteDataException.java
@@ -1,0 +1,7 @@
+package com.dtech.aitrader.v2.kite;
+
+/** Wraps any KiteConnect SDK exception so callers don't depend on the SDK's checked types. */
+public class KiteDataException extends RuntimeException {
+    public KiteDataException(String message) { super(message); }
+    public KiteDataException(String message, Throwable cause) { super(message, cause); }
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/MemsysClient.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/MemsysClient.java
@@ -1,0 +1,61 @@
+package com.dtech.aitrader.v2.memsys;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Typed wrapper around the memsys MCP server. Implementations call the JSON-RPC 2.0
+ * tools/call endpoint exposed at memsys.dheemantech.in/mcp (or wherever configured) and
+ * translate transport/JSON errors into {@link MemsysException}.
+ *
+ * Surface is the subset needed by the AI Trader v2 orchestrator and review flows
+ * (see "AI Trader v2 — Implementation Plan v1.2" memory).
+ */
+public interface MemsysClient {
+
+    MemsysWriteResult writeMemory(
+            String content,
+            String type,
+            List<String> tags,
+            Map<String, Object> metadata,
+            /* nullable */ String parentId,
+            /* nullable */ String supersedes);
+
+    MemsysWriteResult updateMemory(
+            String id,
+            /* nullable */ String content,
+            /* nullable */ List<String> tags,
+            /* nullable */ Map<String, Object> metadata,
+            /* nullable, "replace" | "add" | "remove" */ String tagsOp);
+
+    MemsysWriteResult supersedeMemory(String oldId, String newId);
+
+    MemsysMemory getMemory(String id);
+
+    List<MemsysMemory> searchMemories(
+            String query,
+            /* nullable */ List<String> tags,
+            /* nullable */ String type,
+            /* nullable */ String parentId,
+            /* nullable */ Instant since,
+            /* nullable */ Instant until,
+            int limit);
+
+    /**
+     * Get root + ordered replies for a threaded memory. Replies are sorted by created_at ASC.
+     * The result's first element is the root; subsequent elements are replies in chronological
+     * order. May return an empty list if the id doesn't exist.
+     */
+    ThreadResult getThread(String rootId);
+
+    record ThreadResult(MemsysMemory root, List<MemsysMemory> replies) {
+        /** Returns true when the underlying lookup found nothing. */
+        public boolean isEmpty() { return root == null; }
+    }
+
+    /** Convenience: raw JSON-RPC tools/call passthrough — useful for tools we haven't typed yet. */
+    JsonNode rawToolCall(String toolName, Map<String, Object> arguments);
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/MemsysClient.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/MemsysClient.java
@@ -11,12 +11,18 @@ import java.util.Map;
  * tools/call endpoint exposed at memsys.dheemantech.in/mcp (or wherever configured) and
  * translate transport/JSON errors into {@link MemsysException}.
  *
- * Surface is the subset needed by the AI Trader v2 orchestrator and review flows
- * (see "AI Trader v2 — Implementation Plan v1.2" memory).
+ * <p>Every method takes {@code userId} so the implementation can resolve the right
+ * per-user OAuth access token via {@link com.dtech.aitrader.v2.memsys.auth.MemsysOAuthService}.
+ * memsys uses the token to identify the tenant (JWT.sub → tenant_identities → RLS) — we
+ * never pass user_id in the tool arguments.
+ *
+ * <p>{@code userId} can be {@code null} for system-level calls when a static
+ * {@code memsys.bearer-token} property is configured (operator scripts, smoke tests).
  */
 public interface MemsysClient {
 
     MemsysWriteResult writeMemory(
+            Long userId,
             String content,
             String type,
             List<String> tags,
@@ -25,17 +31,19 @@ public interface MemsysClient {
             /* nullable */ String supersedes);
 
     MemsysWriteResult updateMemory(
+            Long userId,
             String id,
             /* nullable */ String content,
             /* nullable */ List<String> tags,
             /* nullable */ Map<String, Object> metadata,
             /* nullable, "replace" | "add" | "remove" */ String tagsOp);
 
-    MemsysWriteResult supersedeMemory(String oldId, String newId);
+    MemsysWriteResult supersedeMemory(Long userId, String oldId, String newId);
 
-    MemsysMemory getMemory(String id);
+    MemsysMemory getMemory(Long userId, String id);
 
     List<MemsysMemory> searchMemories(
+            Long userId,
             String query,
             /* nullable */ List<String> tags,
             /* nullable */ String type,
@@ -46,16 +54,13 @@ public interface MemsysClient {
 
     /**
      * Get root + ordered replies for a threaded memory. Replies are sorted by created_at ASC.
-     * The result's first element is the root; subsequent elements are replies in chronological
-     * order. May return an empty list if the id doesn't exist.
      */
-    ThreadResult getThread(String rootId);
+    ThreadResult getThread(Long userId, String rootId);
 
     record ThreadResult(MemsysMemory root, List<MemsysMemory> replies) {
-        /** Returns true when the underlying lookup found nothing. */
         public boolean isEmpty() { return root == null; }
     }
 
-    /** Convenience: raw JSON-RPC tools/call passthrough — useful for tools we haven't typed yet. */
-    JsonNode rawToolCall(String toolName, Map<String, Object> arguments);
+    /** Raw JSON-RPC tools/call passthrough — useful for tools we haven't typed yet. */
+    JsonNode rawToolCall(Long userId, String toolName, Map<String, Object> arguments);
 }

--- a/src/main/java/com/dtech/aitrader/v2/memsys/MemsysException.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/MemsysException.java
@@ -1,0 +1,28 @@
+package com.dtech.aitrader.v2.memsys;
+
+/**
+ * Thrown when a memsys MCP call fails. {@link #getCode()} carries the JSON-RPC error code
+ * when the server returned a structured error (e.g. -32602 validation, -32603 internal),
+ * or {@code 0} for transport-level failures.
+ */
+public class MemsysException extends RuntimeException {
+
+    private final int code;
+
+    public MemsysException(String message) {
+        super(message);
+        this.code = 0;
+    }
+
+    public MemsysException(String message, Throwable cause) {
+        super(message, cause);
+        this.code = 0;
+    }
+
+    public MemsysException(int code, String message) {
+        super("memsys " + code + ": " + message);
+        this.code = code;
+    }
+
+    public int getCode() { return code; }
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/MemsysHttpClient.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/MemsysHttpClient.java
@@ -1,0 +1,219 @@
+package com.dtech.aitrader.v2.memsys;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+
+/**
+ * memsys MCP client over plain HTTPS JSON-RPC 2.0.
+ *
+ * Endpoint defaults to {@code https://memsys.dheemantech.in/mcp} but is overridable
+ * via {@code memsys.endpoint} / {@code memsys.bearer-token} in application.properties.
+ *
+ * Per JSON-RPC 2.0 + MCP semantics:
+ *   POST endpoint
+ *   body: {"jsonrpc":"2.0","id":<uuid>,"method":"tools/call","params":{"name":"memory_write","arguments":{...}}}
+ *   200 response: {"jsonrpc":"2.0","id":<uuid>,"result":{"content":[{"type":"text","text":"<json>"}]}}
+ *   on error: {"jsonrpc":"2.0","id":<uuid>,"error":{"code":<int>,"message":"<str>"}}
+ *
+ * The inner content[].text is itself JSON-encoded (the tool's return value). We unwrap one level.
+ */
+@Component
+@Slf4j
+public class MemsysHttpClient implements MemsysClient {
+
+    private final HttpClient http;
+    private final ObjectMapper mapper;
+    private final String endpoint;
+    private final String bearerToken;
+
+    public MemsysHttpClient(
+            ObjectMapper mapper,
+            @Value("${memsys.endpoint:https://memsys.dheemantech.in/mcp}") String endpoint,
+            @Value("${memsys.bearer-token:}") String bearerToken) {
+        this.mapper = mapper;
+        this.endpoint = endpoint;
+        this.bearerToken = bearerToken;
+        this.http = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(15))
+                .build();
+    }
+
+    // ── public surface ───────────────────────────────────────────────
+
+    @Override
+    public MemsysWriteResult writeMemory(String content, String type, List<String> tags,
+                                          Map<String, Object> metadata,
+                                          String parentId, String supersedes) {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("content", content);
+        if (type != null) args.put("type", type);
+        if (tags != null && !tags.isEmpty()) args.put("tags", tags);
+        if (metadata != null && !metadata.isEmpty()) args.put("metadata", metadata);
+        if (parentId != null && !parentId.isBlank()) args.put("parent_id", parentId);
+        if (supersedes != null && !supersedes.isBlank()) args.put("supersedes", supersedes);
+        JsonNode node = call("memory_write", args);
+        return mapper.convertValue(node, MemsysWriteResult.class);
+    }
+
+    @Override
+    public MemsysWriteResult updateMemory(String id, String content, List<String> tags,
+                                           Map<String, Object> metadata, String tagsOp) {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("id", id);
+        if (content != null) args.put("content", content);
+        if (tags != null) args.put("tags", tags);
+        if (metadata != null) args.put("metadata", metadata);
+        if (tagsOp != null) args.put("tags_op", tagsOp);
+        JsonNode node = call("memory_update", args);
+        return mapper.convertValue(node, MemsysWriteResult.class);
+    }
+
+    @Override
+    public MemsysWriteResult supersedeMemory(String oldId, String newId) {
+        Map<String, Object> args = Map.of("old_id", oldId, "new_id", newId);
+        JsonNode node = call("memory_supersede", args);
+        return mapper.convertValue(node, MemsysWriteResult.class);
+    }
+
+    @Override
+    public MemsysMemory getMemory(String id) {
+        JsonNode node = call("memory_get", Map.of("id", id));
+        JsonNode memory = node.has("memory") ? node.get("memory") : node;
+        return mapper.convertValue(memory, MemsysMemory.class);
+    }
+
+    @Override
+    public List<MemsysMemory> searchMemories(String query, List<String> tags, String type,
+                                              String parentId, Instant since, Instant until, int limit) {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("query", query);
+        if (tags != null && !tags.isEmpty()) args.put("tags", tags);
+        if (type != null) args.put("type", type);
+        if (parentId != null && !parentId.isBlank()) args.put("parent_id", parentId);
+        if (since != null) args.put("since", since.toString());
+        if (until != null) args.put("until", until.toString());
+        args.put("limit", limit);
+        JsonNode node = call("memory_search", args);
+        JsonNode results = node.has("results") ? node.get("results") : node;
+        List<MemsysMemory> out = new ArrayList<>();
+        if (results != null && results.isArray()) {
+            for (JsonNode r : results) {
+                out.add(mapper.convertValue(r, MemsysMemory.class));
+            }
+        }
+        return out;
+    }
+
+    @Override
+    public ThreadResult getThread(String rootId) {
+        JsonNode node = call("memory_thread_get", Map.of("root_id", rootId));
+        MemsysMemory root = node.has("root") && !node.get("root").isNull()
+                ? mapper.convertValue(node.get("root"), MemsysMemory.class)
+                : null;
+        List<MemsysMemory> replies = new ArrayList<>();
+        if (node.has("replies") && node.get("replies").isArray()) {
+            for (JsonNode r : node.get("replies")) {
+                replies.add(mapper.convertValue(r, MemsysMemory.class));
+            }
+        }
+        return new ThreadResult(root, replies);
+    }
+
+    @Override
+    public JsonNode rawToolCall(String toolName, Map<String, Object> arguments) {
+        return call(toolName, arguments);
+    }
+
+    // ── transport ────────────────────────────────────────────────────
+
+    private JsonNode call(String toolName, Map<String, Object> arguments) {
+        String requestId = UUID.randomUUID().toString();
+        ObjectNode rpc = mapper.createObjectNode();
+        rpc.put("jsonrpc", "2.0");
+        rpc.put("id", requestId);
+        rpc.put("method", "tools/call");
+        ObjectNode params = mapper.createObjectNode();
+        params.put("name", toolName);
+        params.set("arguments", mapper.valueToTree(arguments == null ? Map.of() : arguments));
+        rpc.set("params", params);
+
+        String body;
+        try {
+            body = mapper.writeValueAsString(rpc);
+        } catch (Exception e) {
+            throw new MemsysException("failed to serialize JSON-RPC body for " + toolName, e);
+        }
+
+        HttpRequest.Builder req = HttpRequest.newBuilder(URI.create(endpoint))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json")
+                .timeout(Duration.ofSeconds(30))
+                .POST(HttpRequest.BodyPublishers.ofString(body));
+        if (bearerToken != null && !bearerToken.isBlank()) {
+            req.header("Authorization", "Bearer " + bearerToken);
+        }
+
+        HttpResponse<String> res;
+        try {
+            res = http.send(req.build(), HttpResponse.BodyHandlers.ofString());
+        } catch (Exception e) {
+            throw new MemsysException("memsys MCP transport failure for " + toolName, e);
+        }
+
+        if (res.statusCode() < 200 || res.statusCode() >= 300) {
+            throw new MemsysException("memsys MCP HTTP " + res.statusCode() + " for " + toolName
+                    + ": " + truncate(res.body(), 400));
+        }
+
+        JsonNode root;
+        try {
+            root = mapper.readTree(res.body());
+        } catch (Exception e) {
+            throw new MemsysException("memsys MCP returned malformed JSON for " + toolName + ": "
+                    + truncate(res.body(), 400), e);
+        }
+
+        if (root.has("error") && !root.get("error").isNull()) {
+            JsonNode err = root.get("error");
+            int code = err.path("code").asInt(0);
+            String message = err.path("message").asText("(no message)");
+            throw new MemsysException(code, toolName + " — " + message);
+        }
+
+        // result.content[0].text is JSON-encoded tool output — unwrap one level.
+        JsonNode result = root.path("result");
+        if (!result.isObject()) {
+            throw new MemsysException(toolName + " — missing result object");
+        }
+        JsonNode content = result.path("content");
+        if (content.isArray() && content.size() > 0) {
+            String text = content.get(0).path("text").asText(null);
+            if (text != null) {
+                try {
+                    return mapper.readTree(text);
+                } catch (Exception e) {
+                    // content[].text wasn't JSON — return raw object instead
+                    return content.get(0);
+                }
+            }
+        }
+        return result;
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() > max ? s.substring(0, max) + "…" : s;
+    }
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/MemsysHttpClient.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/MemsysHttpClient.java
@@ -1,5 +1,6 @@
 package com.dtech.aitrader.v2.memsys;
 
+import com.dtech.aitrader.v2.memsys.auth.MemsysOAuthService;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -18,16 +19,15 @@ import java.util.*;
 /**
  * memsys MCP client over plain HTTPS JSON-RPC 2.0.
  *
- * Endpoint defaults to {@code https://memsys.dheemantech.in/mcp} but is overridable
- * via {@code memsys.endpoint} / {@code memsys.bearer-token} in application.properties.
+ * <p>Auth resolution:
+ * <ol>
+ *   <li>If {@code userId} is non-null: {@link MemsysOAuthService#getValidAccessToken(Long)}
+ *       returns the user's OAuth token; auto-refreshed when expiring.</li>
+ *   <li>Otherwise: falls back to {@code memsys.bearer-token} property (operator/script use).</li>
+ * </ol>
  *
- * Per JSON-RPC 2.0 + MCP semantics:
- *   POST endpoint
- *   body: {"jsonrpc":"2.0","id":<uuid>,"method":"tools/call","params":{"name":"memory_write","arguments":{...}}}
- *   200 response: {"jsonrpc":"2.0","id":<uuid>,"result":{"content":[{"type":"text","text":"<json>"}]}}
- *   on error: {"jsonrpc":"2.0","id":<uuid>,"error":{"code":<int>,"message":"<str>"}}
- *
- * The inner content[].text is itself JSON-encoded (the tool's return value). We unwrap one level.
+ * <p>On HTTP 401 from memsys: force a refresh via
+ * {@link MemsysOAuthService#forceRefresh(Long)} and retry the call once.
  */
 @Component
 @Slf4j
@@ -35,16 +35,19 @@ public class MemsysHttpClient implements MemsysClient {
 
     private final HttpClient http;
     private final ObjectMapper mapper;
+    private final MemsysOAuthService oauthService;
     private final String endpoint;
-    private final String bearerToken;
+    private final String fallbackBearer;
 
     public MemsysHttpClient(
             ObjectMapper mapper,
+            MemsysOAuthService oauthService,
             @Value("${memsys.endpoint:https://memsys.dheemantech.in/mcp}") String endpoint,
-            @Value("${memsys.bearer-token:}") String bearerToken) {
+            @Value("${memsys.bearer-token:}") String fallbackBearer) {
         this.mapper = mapper;
+        this.oauthService = oauthService;
         this.endpoint = endpoint;
-        this.bearerToken = bearerToken;
+        this.fallbackBearer = fallbackBearer;
         this.http = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(15))
                 .build();
@@ -53,7 +56,7 @@ public class MemsysHttpClient implements MemsysClient {
     // ── public surface ───────────────────────────────────────────────
 
     @Override
-    public MemsysWriteResult writeMemory(String content, String type, List<String> tags,
+    public MemsysWriteResult writeMemory(Long userId, String content, String type, List<String> tags,
                                           Map<String, Object> metadata,
                                           String parentId, String supersedes) {
         Map<String, Object> args = new LinkedHashMap<>();
@@ -63,12 +66,11 @@ public class MemsysHttpClient implements MemsysClient {
         if (metadata != null && !metadata.isEmpty()) args.put("metadata", metadata);
         if (parentId != null && !parentId.isBlank()) args.put("parent_id", parentId);
         if (supersedes != null && !supersedes.isBlank()) args.put("supersedes", supersedes);
-        JsonNode node = call("memory_write", args);
-        return mapper.convertValue(node, MemsysWriteResult.class);
+        return mapper.convertValue(call(userId, "memory_write", args), MemsysWriteResult.class);
     }
 
     @Override
-    public MemsysWriteResult updateMemory(String id, String content, List<String> tags,
+    public MemsysWriteResult updateMemory(Long userId, String id, String content, List<String> tags,
                                            Map<String, Object> metadata, String tagsOp) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("id", id);
@@ -76,26 +78,24 @@ public class MemsysHttpClient implements MemsysClient {
         if (tags != null) args.put("tags", tags);
         if (metadata != null) args.put("metadata", metadata);
         if (tagsOp != null) args.put("tags_op", tagsOp);
-        JsonNode node = call("memory_update", args);
-        return mapper.convertValue(node, MemsysWriteResult.class);
+        return mapper.convertValue(call(userId, "memory_update", args), MemsysWriteResult.class);
     }
 
     @Override
-    public MemsysWriteResult supersedeMemory(String oldId, String newId) {
-        Map<String, Object> args = Map.of("old_id", oldId, "new_id", newId);
-        JsonNode node = call("memory_supersede", args);
-        return mapper.convertValue(node, MemsysWriteResult.class);
+    public MemsysWriteResult supersedeMemory(Long userId, String oldId, String newId) {
+        return mapper.convertValue(call(userId, "memory_supersede", Map.of("old_id", oldId, "new_id", newId)),
+                MemsysWriteResult.class);
     }
 
     @Override
-    public MemsysMemory getMemory(String id) {
-        JsonNode node = call("memory_get", Map.of("id", id));
+    public MemsysMemory getMemory(Long userId, String id) {
+        JsonNode node = call(userId, "memory_get", Map.of("id", id));
         JsonNode memory = node.has("memory") ? node.get("memory") : node;
         return mapper.convertValue(memory, MemsysMemory.class);
     }
 
     @Override
-    public List<MemsysMemory> searchMemories(String query, List<String> tags, String type,
+    public List<MemsysMemory> searchMemories(Long userId, String query, List<String> tags, String type,
                                               String parentId, Instant since, Instant until, int limit) {
         Map<String, Object> args = new LinkedHashMap<>();
         args.put("query", query);
@@ -105,7 +105,7 @@ public class MemsysHttpClient implements MemsysClient {
         if (since != null) args.put("since", since.toString());
         if (until != null) args.put("until", until.toString());
         args.put("limit", limit);
-        JsonNode node = call("memory_search", args);
+        JsonNode node = call(userId, "memory_search", args);
         JsonNode results = node.has("results") ? node.get("results") : node;
         List<MemsysMemory> out = new ArrayList<>();
         if (results != null && results.isArray()) {
@@ -117,8 +117,8 @@ public class MemsysHttpClient implements MemsysClient {
     }
 
     @Override
-    public ThreadResult getThread(String rootId) {
-        JsonNode node = call("memory_thread_get", Map.of("root_id", rootId));
+    public ThreadResult getThread(Long userId, String rootId) {
+        JsonNode node = call(userId, "memory_thread_get", Map.of("root_id", rootId));
         MemsysMemory root = node.has("root") && !node.get("root").isNull()
                 ? mapper.convertValue(node.get("root"), MemsysMemory.class)
                 : null;
@@ -132,13 +132,44 @@ public class MemsysHttpClient implements MemsysClient {
     }
 
     @Override
-    public JsonNode rawToolCall(String toolName, Map<String, Object> arguments) {
-        return call(toolName, arguments);
+    public JsonNode rawToolCall(Long userId, String toolName, Map<String, Object> arguments) {
+        return call(userId, toolName, arguments);
     }
 
-    // ── transport ────────────────────────────────────────────────────
+    // ── transport with retry-on-401 ──────────────────────────────────
 
-    private JsonNode call(String toolName, Map<String, Object> arguments) {
+    private JsonNode call(Long userId, String toolName, Map<String, Object> arguments) {
+        String token = resolveToken(userId);
+        try {
+            return doCall(token, toolName, arguments);
+        } catch (MemsysException e) {
+            // 401 → force refresh + retry once. Only when we have a userId to refresh against.
+            if (userId != null && e.getCode() == 401) {
+                log.info("[memsys] got 401 for tool={} userId={} — forcing refresh + retrying", toolName, userId);
+                Optional<String> fresh = oauthService.forceRefresh(userId);
+                if (fresh.isPresent()) {
+                    return doCall(fresh.get(), toolName, arguments);
+                }
+            }
+            throw e;
+        }
+    }
+
+    private String resolveToken(Long userId) {
+        if (userId != null) {
+            Optional<String> t = oauthService.getValidAccessToken(userId);
+            if (t.isPresent()) return t.get();
+            // No OAuth config for this user — fall through to fallback token if present
+            log.debug("[memsys] no OAuth config for userId={}, falling back to static bearer", userId);
+        }
+        if (fallbackBearer != null && !fallbackBearer.isBlank()) return fallbackBearer;
+        throw new MemsysException("no memsys credentials available — "
+                + (userId == null
+                ? "set memsys.bearer-token or call with userId"
+                : "user " + userId + " has not connected memsys"));
+    }
+
+    private JsonNode doCall(String bearer, String toolName, Map<String, Object> arguments) {
         String requestId = UUID.randomUUID().toString();
         ObjectNode rpc = mapper.createObjectNode();
         rpc.put("jsonrpc", "2.0");
@@ -161,8 +192,8 @@ public class MemsysHttpClient implements MemsysClient {
                 .header("Accept", "application/json")
                 .timeout(Duration.ofSeconds(30))
                 .POST(HttpRequest.BodyPublishers.ofString(body));
-        if (bearerToken != null && !bearerToken.isBlank()) {
-            req.header("Authorization", "Bearer " + bearerToken);
+        if (bearer != null && !bearer.isBlank()) {
+            req.header("Authorization", "Bearer " + bearer);
         }
 
         HttpResponse<String> res;
@@ -172,6 +203,9 @@ public class MemsysHttpClient implements MemsysClient {
             throw new MemsysException("memsys MCP transport failure for " + toolName, e);
         }
 
+        if (res.statusCode() == 401 || res.statusCode() == 403) {
+            throw new MemsysException(401, toolName + " — HTTP " + res.statusCode() + " unauthorized");
+        }
         if (res.statusCode() < 200 || res.statusCode() >= 300) {
             throw new MemsysException("memsys MCP HTTP " + res.statusCode() + " for " + toolName
                     + ": " + truncate(res.body(), 400));
@@ -189,7 +223,9 @@ public class MemsysHttpClient implements MemsysClient {
             JsonNode err = root.get("error");
             int code = err.path("code").asInt(0);
             String message = err.path("message").asText("(no message)");
-            throw new MemsysException(code, toolName + " — " + message);
+            JsonNode data = err.path("data");
+            String dataStr = (data.isMissingNode() || data.isNull()) ? "" : " · data=" + data.toString();
+            throw new MemsysException(code, toolName + " — " + message + dataStr);
         }
 
         // result.content[0].text is JSON-encoded tool output — unwrap one level.
@@ -204,7 +240,6 @@ public class MemsysHttpClient implements MemsysClient {
                 try {
                     return mapper.readTree(text);
                 } catch (Exception e) {
-                    // content[].text wasn't JSON — return raw object instead
                     return content.get(0);
                 }
             }

--- a/src/main/java/com/dtech/aitrader/v2/memsys/MemsysMemory.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/MemsysMemory.java
@@ -1,0 +1,42 @@
+package com.dtech.aitrader.v2.memsys;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * A memsys memory as returned by the memsys MCP. Mirrors the shape returned by memory_get
+ * and memory_search results. Tolerant of unknown fields so the schema can evolve server-side.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MemsysMemory {
+    private String id;
+    private String content;
+    /** One of: note, decision, fact, snippet, question. */
+    private String type;
+    private List<String> tags;
+    private JsonNode metadata;
+
+    private Integer version;
+    @JsonProperty("is_current") private Boolean isCurrent;
+    private String supersedes;
+    @JsonProperty("superseded_by") private String supersededBy;
+
+    /** Native threading — populated only when threading feature is in use. */
+    @JsonProperty("parent_id") private String parentId;
+
+    @JsonProperty("created_at") private Instant createdAt;
+    @JsonProperty("updated_at") private Instant updatedAt;
+    @JsonProperty("deleted_at") private Instant deletedAt;
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/MemsysWriteResult.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/MemsysWriteResult.java
@@ -1,0 +1,25 @@
+package com.dtech.aitrader.v2.memsys;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/** Response from memory_write / memory_update / memory_supersede. */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MemsysWriteResult {
+    private String id;
+    private Integer version;
+    private Boolean deduped;
+    @JsonProperty("merged_into") private String mergedInto;
+    @JsonProperty("created_at") private Instant createdAt;
+    @JsonProperty("request_id") private String requestId;
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/auth/MemsysAuthController.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/auth/MemsysAuthController.java
@@ -1,0 +1,132 @@
+package com.dtech.aitrader.v2.memsys.auth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.view.RedirectView;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Endpoints that drive the memsys OAuth flow for algotrade users.
+ *
+ * Per-user:
+ *   GET  /api/admin/memsys-configs/{userId}/connect   — auto-DCR if needed, then redirects browser to Cognito authorize
+ *   GET  /memsys/callback                              — Cognito redirects here with code → tokens
+ */
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class MemsysAuthController {
+
+    private final MemsysOAuthService oauthService;
+    private final UserMemsysConfigRepository userMemsysConfigRepository;
+    private final MemsysKiteOnboardingService kiteOnboardingService;
+
+    @Value("${frontend.base-url:http://localhost:5173}")
+    private String frontendBaseUrl;
+
+    // ── per-user: kick off the Connect flow (self-bootstrapping DCR) ────
+
+    @GetMapping("/api/admin/memsys-configs/{userId}/connect")
+    public RedirectView connect(@PathVariable Long userId, Authentication auth) {
+        try {
+            // Self-bootstrapping: check if user has a registered DCR client. If not, register it.
+            UserMemsysConfig cfg = userMemsysConfigRepository.findByUserId(userId).orElse(null);
+            if (cfg == null || cfg.getClientId() == null || cfg.getClientId().isBlank()) {
+                log.info("[memsys-oauth] userId={} missing DCR client; registering now", userId);
+                oauthService.registerAndPersistForUser(userId, "AlgoTrade User " + userId);
+            }
+
+            // CSRF protection: bind state to (userId + random nonce). Real impl could store in
+            // a server-side state cache or a signed JWT; for now we use a URL-safe encoding that
+            // the callback handler can parse. Cognito echoes state back verbatim.
+            String nonce = UUID.randomUUID().toString();
+            String state = userId + ":" + nonce;
+            String url = oauthService.buildAuthorizeUrl(userId, state);
+            log.info("[memsys-oauth] redirecting userId={} to memsys authorize URL", userId);
+            return new RedirectView(url);
+        } catch (Exception e) {
+            log.error("[memsys-oauth] DCR registration failed for userId={}: {}", userId, e.getMessage(), e);
+            return new RedirectView(frontUrl("/admin/memsys?status=error&reason=dcr_failed"));
+        }
+    }
+
+    // ── Cognito callback: exchange code, persist tokens, redirect to UI ──
+
+    @GetMapping("/memsys/callback")
+    public RedirectView callback(
+            @RequestParam(required = false) String code,
+            @RequestParam(required = false) String state,
+            @RequestParam(required = false, name = "error") String errorParam,
+            @RequestParam(required = false, name = "error_description") String errorDescription) {
+
+        if (errorParam != null && !errorParam.isBlank()) {
+            log.warn("[memsys-oauth] callback received error: {} {}", errorParam, errorDescription);
+            return new RedirectView(frontUrl("/admin/memsys?status=error&reason=" + errorParam));
+        }
+        if (code == null || code.isBlank() || state == null || state.isBlank()) {
+            log.warn("[memsys-oauth] callback missing code or state");
+            return new RedirectView(frontUrl("/admin/memsys?status=error&reason=missing_params"));
+        }
+
+        // Decode state — expected "<userId>:<nonce>".
+        Long userId;
+        try {
+            int idx = state.indexOf(':');
+            String userPart = idx > 0 ? state.substring(0, idx) : state;
+            userId = Long.parseLong(userPart);
+        } catch (NumberFormatException nfe) {
+            log.warn("[memsys-oauth] callback got unparseable state={}", state);
+            return new RedirectView(frontUrl("/admin/memsys?status=error&reason=bad_state"));
+        }
+
+        try {
+            MemsysOAuthService.TokenSet tokens = oauthService.exchangeCode(userId, code);
+            UserMemsysConfig saved = oauthService.persistTokens(userId, tokens);
+            log.info("[memsys-oauth] connected memsys for userId={} memsys_tenant_sub={} scopes={}",
+                    userId, saved.getMemsysTenantSub(), saved.getScopes());
+            return new RedirectView(frontUrl("/admin/memsys?status=connected"));
+        } catch (Exception e) {
+            log.error("[memsys-oauth] callback exchange failed for state={}: {}", state, e.getMessage(), e);
+            return new RedirectView(frontUrl("/admin/memsys?status=error&reason=exchange_failed"));
+        }
+    }
+
+    // ── per-user: push Kite creds into memsys vault ─────────────────────
+
+    @PostMapping("/api/admin/memsys-configs/{userId}/enable-kite")
+    public ResponseEntity<?> enableKite(@PathVariable Long userId, Authentication auth) {
+        try {
+            com.fasterxml.jackson.databind.JsonNode result = kiteOnboardingService.enableForUser(userId);
+            return ResponseEntity.ok(Map.of(
+                    "userId", userId,
+                    "enabled", true,
+                    "memsys_response", result == null ? "(null)" : result
+            ));
+        } catch (IllegalStateException ise) {
+            log.warn("[memsys-kite-onboard] enable-kite blocked for userId={}: {}", userId, ise.getMessage());
+            return ResponseEntity.status(400).body(Map.of(
+                    "userId", userId,
+                    "enabled", false,
+                    "error", ise.getMessage()
+            ));
+        } catch (Exception e) {
+            log.error("[memsys-kite-onboard] enable-kite failed for userId={}", userId, e);
+            return ResponseEntity.status(500).body(Map.of(
+                    "userId", userId,
+                    "enabled", false,
+                    "error", e.getMessage()
+            ));
+        }
+    }
+
+    private String frontUrl(String suffix) {
+        String base = frontendBaseUrl == null ? "" : frontendBaseUrl.replaceAll("/+$", "");
+        return base + suffix;
+    }
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/auth/MemsysKiteOnboardingService.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/auth/MemsysKiteOnboardingService.java
@@ -1,0 +1,83 @@
+package com.dtech.aitrader.v2.memsys.auth;
+
+import com.dtech.aitrader.v2.memsys.MemsysClient;
+import com.dtech.kitecon.kite.entity.UserKiteConfig;
+import com.dtech.kitecon.kite.repository.UserKiteConfigRepository;
+import com.dtech.kitecon.service.copilot.CopilotEncryptionService;
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Bridges algotrade's existing per-user Kite credentials (in {@code user_kite_config})
+ * into memsys's per-tenant Kite skill vault via the {@code memsys_enable_kite} tool.
+ *
+ * Uses Mode C (password + TOTP secret) so the user's tenant on memsys can auto-renew
+ * the Zerodha access token daily without manual paste. See memsys memory
+ * {@code 95159c69} for the Mode C design.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MemsysKiteOnboardingService {
+
+    private final UserKiteConfigRepository kiteRepo;
+    private final CopilotEncryptionService encryptionService;
+    private final MemsysClient memsys;
+
+    /**
+     * Enable the Kite skill on memsys for the given algotrade user. Reads creds from
+     * {@code user_kite_config}, decrypts password + TOTP secret, and calls
+     * {@code memsys_enable_kite}. Idempotent on memsys side — re-calling overwrites.
+     *
+     * @return memsys's raw response (tool output JSON) — useful for the controller to surface status
+     * @throws IllegalStateException if no active Kite config exists for the user or required fields are missing
+     */
+    public JsonNode enableForUser(Long platformUserId) {
+        UserKiteConfig cfg = kiteRepo.findFirstByPlatformUserIdAndActiveTrue(platformUserId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "no active user_kite_config row for platform_user_id=" + platformUserId
+                                + " — set up Kite locally first"));
+
+        require(cfg.getApiKey(), "apiKey");
+        require(cfg.getApiSecret(), "apiSecret");
+        require(cfg.getKiteUserId(), "kiteUserId");
+        require(cfg.getZerodhaPasswordEncrypted(), "zerodhaPasswordEncrypted");
+        require(cfg.getTotpSecretEncrypted(), "totpSecretEncrypted");
+
+        String password = encryptionService.decrypt(cfg.getZerodhaPasswordEncrypted());
+        String totp = encryptionService.decrypt(cfg.getTotpSecretEncrypted());
+
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("api_key", cfg.getApiKey());
+        args.put("api_secret", cfg.getApiSecret());
+        args.put("user_id", cfg.getKiteUserId());
+        args.put("password", password);
+        args.put("totp_secret", totp);
+
+        log.info("[memsys-kite-onboard] calling memsys_enable_kite for platformUserId={} kite_user_id={}",
+                platformUserId, cfg.getKiteUserId());
+        JsonNode result = memsys.rawToolCall(platformUserId, "memsys_enable_kite", args);
+        log.info("[memsys-kite-onboard] memsys_enable_kite returned for platformUserId={}: keys={}",
+                platformUserId, result == null ? "null" : fieldNames(result));
+        return result;
+    }
+
+    private static void require(String v, String name) {
+        if (v == null || v.isBlank()) {
+            throw new IllegalStateException("user_kite_config." + name + " is empty — cannot enable Kite on memsys");
+        }
+    }
+
+    private static String fieldNames(JsonNode n) {
+        if (!n.isObject()) return n.getNodeType().toString();
+        List<String> names = new java.util.ArrayList<>();
+        n.fieldNames().forEachRemaining(names::add);
+        return String.join(",", names);
+    }
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/auth/MemsysOAuthException.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/auth/MemsysOAuthException.java
@@ -1,0 +1,6 @@
+package com.dtech.aitrader.v2.memsys.auth;
+
+public class MemsysOAuthException extends RuntimeException {
+    public MemsysOAuthException(String message) { super(message); }
+    public MemsysOAuthException(String message, Throwable cause) { super(message, cause); }
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/auth/MemsysOAuthProperties.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/auth/MemsysOAuthProperties.java
@@ -1,0 +1,36 @@
+package com.dtech.aitrader.v2.memsys.auth;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * memsys OAuth infrastructure config. Populated from application.properties or env.
+ *
+ * <p>Per-user DCR client credentials (client_id + client_secret) are stored per-user
+ * on the {@code user_memsys_config} row, not system-wide. Only infrastructure URLs
+ * (authorize, token, DCR endpoints, redirect URI, and scopes) come from properties.
+ */
+@Configuration
+@ConfigurationProperties(prefix = "memsys.oauth")
+@Data
+public class MemsysOAuthProperties {
+
+    /** Cognito authorize URL (login). Default: https://memauth.dheemantech.in/login */
+    private String authorizeUrl = "https://memauth.dheemantech.in/login";
+
+    /** Cognito token endpoint. Default: https://memauth.dheemantech.in/oauth2/token */
+    private String tokenUrl = "https://memauth.dheemantech.in/oauth2/token";
+
+    /** memsys DCR endpoint for one-time client registration. */
+    private String dcrUrl = "https://memsys.dheemantech.in/oauth/register";
+
+    /** Redirect URI registered with the DCR client. Must match exactly. */
+    private String redirectUri = "https://tradeapi.dheemantech.in/memsys/callback";
+
+    /**
+     * Scopes requested at authorize-time. Cognito custom scopes are URI-prefixed —
+     * "https://memsys.dheemantech.in/memory.read https://memsys.dheemantech.in/memory.write".
+     */
+    private String scopes = "https://memsys.dheemantech.in/memory.read https://memsys.dheemantech.in/memory.write";
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/auth/MemsysOAuthService.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/auth/MemsysOAuthService.java
@@ -1,0 +1,378 @@
+package com.dtech.aitrader.v2.memsys.auth;
+
+import com.dtech.kitecon.service.copilot.CopilotEncryptionService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * memsys OAuth flow + token lifecycle. Built on the two-tier DCR shipped by memsys on
+ * 2026-05-18 (memsys memory 060dad62-bbbb-499b-8c6c-18886295108e).
+ *
+ * Lifecycle:
+ *  1. Operator does one-time DCR registration → captures client_id + client_secret.
+ *  2. User clicks "Connect memsys" → algotrade builds the authorize URL, browser redirects.
+ *  3. Cognito-hosted Google sign-in → callback to /memsys/callback with code.
+ *  4. exchangeCode() trades code for {access_token, refresh_token, id_token}.
+ *  5. persistTokens() encrypts + stores in user_memsys_config.
+ *  6. getValidAccessToken() returns a usable bearer; auto-refreshes when expired.
+ *  7. refreshAccessToken() rotates RT, returns new access_token.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MemsysOAuthService {
+
+    private static final long REFRESH_SLACK_SECONDS = 60; // refresh if expiring within 60s
+
+    private final MemsysOAuthProperties props;
+    private final UserMemsysConfigRepository repository;
+    private final CopilotEncryptionService encryptionService;
+    private final ObjectMapper mapper;
+
+    private final HttpClient http = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(15))
+            .build();
+
+    // ── Step 1: one-time DCR registration → persist per-user ─────────────
+
+    /**
+     * Register a confidential OAuth client with memsys DCR, then upsert the user's
+     * {@code user_memsys_config} row with the issued credentials.
+     *
+     * @param userId algotrade user id
+     * @param clientName human-readable client name for DCR
+     * @return persisted UserMemsysConfig with clientId + clientSecretEncrypted set
+     */
+    @Transactional
+    public UserMemsysConfig registerAndPersistForUser(Long userId, String clientName) {
+        // Call DCR to get client_id + client_secret
+        DcrResponse dcr = performDcr(clientName);
+
+        // Upsert user_memsys_config row
+        UserMemsysConfig cfg = repository.findByUserId(userId)
+                .orElseGet(() -> UserMemsysConfig.builder()
+                        .userId(userId)
+                        .active(true)
+                        .build());
+
+        if (cfg.getClientId() != null && !cfg.getClientId().isBlank()) {
+            log.warn("[memsys-oauth] userId={} already has clientId set; overwriting with new DCR registration",
+                    userId);
+        }
+
+        cfg.setClientId(dcr.clientId);
+        cfg.setClientSecretEncrypted(encryptionService.encrypt(dcr.clientSecret));
+        cfg.setActive(true);
+        UserMemsysConfig saved = repository.save(cfg);
+
+        log.info("[memsys-oauth] registered + persisted DCR client for userId={}; client_id={}",
+                userId, dcr.clientId);
+        return saved;
+    }
+
+    private DcrResponse performDcr(String clientName) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("client_name", clientName);
+        body.put("software_id", "algotrade");
+        body.put("redirect_uris", java.util.List.of(props.getRedirectUri()));
+        body.put("token_endpoint_auth_method", "client_secret_post");
+        body.put("scope", "memory.read memory.write");
+        body.put("grant_types", java.util.List.of("authorization_code", "refresh_token"));
+
+        String bodyJson;
+        try {
+            bodyJson = mapper.writeValueAsString(body);
+        } catch (Exception e) {
+            throw new MemsysOAuthException("failed to serialize DCR body", e);
+        }
+
+        HttpRequest req = HttpRequest.newBuilder(URI.create(props.getDcrUrl()))
+                .header("Content-Type", "application/json")
+                .timeout(Duration.ofSeconds(20))
+                .POST(HttpRequest.BodyPublishers.ofString(bodyJson))
+                .build();
+
+        HttpResponse<String> res = send(req);
+        if (res.statusCode() < 200 || res.statusCode() >= 300) {
+            throw new MemsysOAuthException(
+                    "DCR registration failed: HTTP " + res.statusCode() + " " + truncate(res.body(), 400));
+        }
+        try {
+            JsonNode root = mapper.readTree(res.body());
+            return new DcrResponse(
+                    root.path("client_id").asText(null),
+                    root.path("client_secret").asText(null),
+                    root.path("redirect_uris").toString(),
+                    root.path("scope").asText("")
+            );
+        } catch (Exception e) {
+            throw new MemsysOAuthException("DCR registration returned malformed JSON: " + truncate(res.body(), 400), e);
+        }
+    }
+
+    private record DcrResponse(String clientId, String clientSecret, String redirectUris, String scope) {}
+
+    // ── Step 2: build the authorize URL the browser is redirected to ────
+
+    /**
+     * Build the authorize URL for the given user, using their per-user clientId.
+     *
+     * @param userId algotrade user id
+     * @param state CSRF state token
+     * @return authorize URL
+     */
+    public String buildAuthorizeUrl(Long userId, String state) {
+        UserMemsysConfig cfg = ensureClientForUser(userId);
+        StringBuilder sb = new StringBuilder(props.getAuthorizeUrl());
+        sb.append("?response_type=code");
+        sb.append("&client_id=").append(URLEncoder.encode(cfg.getClientId(), StandardCharsets.UTF_8));
+        sb.append("&redirect_uri=").append(URLEncoder.encode(props.getRedirectUri(), StandardCharsets.UTF_8));
+        sb.append("&scope=").append(URLEncoder.encode(props.getScopes(), StandardCharsets.UTF_8));
+        sb.append("&state=").append(URLEncoder.encode(state, StandardCharsets.UTF_8));
+        return sb.toString();
+    }
+
+    /**
+     * Validate that the user has a registered memsys OAuth client.
+     *
+     * @param userId algotrade user id
+     * @return the UserMemsysConfig with clientId + clientSecretEncrypted set
+     * @throws MemsysOAuthException if client not registered
+     */
+    private UserMemsysConfig ensureClientForUser(Long userId) {
+        UserMemsysConfig cfg = repository.findByUserId(userId)
+                .orElseThrow(() -> new MemsysOAuthException(
+                        "user " + userId + " has not registered a memsys OAuth client; "
+                                + "call /api/admin/memsys-configs/{userId}/dcr-register first"));
+        if (cfg.getClientId() == null || cfg.getClientId().isBlank()) {
+            throw new MemsysOAuthException(
+                    "user " + userId + " has not registered a memsys OAuth client; "
+                            + "call /api/admin/memsys-configs/{userId}/dcr-register first");
+        }
+        return cfg;
+    }
+
+    // ── Step 3: exchange auth code for tokens ───────────────────────────
+
+    /**
+     * Exchange the authorization code for tokens.
+     *
+     * @param userId algotrade user id
+     * @param code authorization code from Cognito callback
+     * @return token set
+     */
+    public TokenSet exchangeCode(Long userId, String code) {
+        UserMemsysConfig cfg = ensureClientForUser(userId);
+        String clientSecret;
+        try {
+            clientSecret = encryptionService.decrypt(cfg.getClientSecretEncrypted());
+        } catch (Exception e) {
+            throw new MemsysOAuthException("failed to decrypt client_secret for userId=" + userId, e);
+        }
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("grant_type", "authorization_code");
+        form.put("code", code);
+        form.put("client_id", cfg.getClientId());
+        form.put("client_secret", clientSecret);
+        form.put("redirect_uri", props.getRedirectUri());
+
+        return postToken(form);
+    }
+
+    // ── Step 4: persist tokens for an algotrade user ────────────────────
+
+    @Transactional
+    public UserMemsysConfig persistTokens(Long userId, TokenSet tokens) {
+        UserMemsysConfig existing = repository.findByUserId(userId).orElse(null);
+        UserMemsysConfig cfg = existing != null ? existing : UserMemsysConfig.builder()
+                .userId(userId)
+                .active(true)
+                .build();
+        cfg.setAccessTokenEncrypted(encryptionService.encrypt(tokens.accessToken()));
+        cfg.setRefreshTokenEncrypted(encryptionService.encrypt(tokens.refreshToken()));
+        cfg.setExpiresAt(tokens.expiresAt());
+        cfg.setScopes(tokens.scope());
+        cfg.setMemsysTenantSub(tokens.subject());
+        cfg.setDisplayName(tokens.displayName());
+        cfg.setActive(true);
+        return repository.save(cfg);
+    }
+
+    // ── Step 5: get a valid access token (refresh on-the-fly if expiring) ──
+
+    @Transactional
+    public Optional<String> getValidAccessToken(Long userId) {
+        Optional<UserMemsysConfig> opt = repository.findByUserIdAndActiveTrue(userId);
+        if (opt.isEmpty()) return Optional.empty();
+        UserMemsysConfig cfg = opt.get();
+
+        if (cfg.getExpiresAt() == null
+                || cfg.getExpiresAt().minusSeconds(REFRESH_SLACK_SECONDS).isBefore(Instant.now())) {
+            log.info("[memsys-oauth] access token expiring (or expired) for userId={} — refreshing", userId);
+            return refreshAndReturnAccessToken(cfg);
+        }
+
+        try {
+            return Optional.of(encryptionService.decrypt(cfg.getAccessTokenEncrypted()));
+        } catch (Exception e) {
+            log.warn("[memsys-oauth] failed to decrypt access token for userId={}: {}", userId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /** Forced refresh — used by retry-on-401 in the MCP client. */
+    @Transactional
+    public Optional<String> forceRefresh(Long userId) {
+        Optional<UserMemsysConfig> opt = repository.findByUserIdAndActiveTrue(userId);
+        if (opt.isEmpty()) return Optional.empty();
+        return refreshAndReturnAccessToken(opt.get());
+    }
+
+    private Optional<String> refreshAndReturnAccessToken(UserMemsysConfig cfg) {
+        String refreshToken;
+        try {
+            refreshToken = encryptionService.decrypt(cfg.getRefreshTokenEncrypted());
+        } catch (Exception e) {
+            log.error("[memsys-oauth] failed to decrypt refresh token for userId={}: {}",
+                    cfg.getUserId(), e.getMessage());
+            return Optional.empty();
+        }
+        if (cfg.getClientId() == null || cfg.getClientId().isBlank()) {
+            log.error("[memsys-oauth] userId={} missing clientId; DCR registration incomplete", cfg.getUserId());
+            return Optional.empty();
+        }
+        String clientSecret;
+        try {
+            clientSecret = encryptionService.decrypt(cfg.getClientSecretEncrypted());
+        } catch (Exception e) {
+            log.error("[memsys-oauth] failed to decrypt client_secret for userId={}: {}",
+                    cfg.getUserId(), e.getMessage());
+            return Optional.empty();
+        }
+        Map<String, String> form = new LinkedHashMap<>();
+        form.put("grant_type", "refresh_token");
+        form.put("refresh_token", refreshToken);
+        form.put("client_id", cfg.getClientId());
+        form.put("client_secret", clientSecret);
+
+        try {
+            TokenSet tokens = postToken(form);
+            cfg.setAccessTokenEncrypted(encryptionService.encrypt(tokens.accessToken()));
+            // Cognito rotates RTs by default — when present in the response, replace ours.
+            if (tokens.refreshToken() != null && !tokens.refreshToken().isBlank()) {
+                cfg.setRefreshTokenEncrypted(encryptionService.encrypt(tokens.refreshToken()));
+            }
+            cfg.setExpiresAt(tokens.expiresAt());
+            if (tokens.scope() != null && !tokens.scope().isBlank()) cfg.setScopes(tokens.scope());
+            repository.save(cfg);
+            return Optional.of(tokens.accessToken());
+        } catch (Exception e) {
+            log.error("[memsys-oauth] refresh failed for userId={}: {}", cfg.getUserId(), e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    // ── shared token-endpoint poster ───────────────────────────────────
+
+    private TokenSet postToken(Map<String, String> form) {
+        String formBody = form.entrySet().stream()
+                .map(e -> URLEncoder.encode(e.getKey(), StandardCharsets.UTF_8)
+                        + "=" + URLEncoder.encode(e.getValue() == null ? "" : e.getValue(), StandardCharsets.UTF_8))
+                .collect(Collectors.joining("&"));
+
+        HttpRequest req = HttpRequest.newBuilder(URI.create(props.getTokenUrl()))
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .header("Accept", "application/json")
+                .timeout(Duration.ofSeconds(20))
+                .POST(HttpRequest.BodyPublishers.ofString(formBody))
+                .build();
+
+        HttpResponse<String> res = send(req);
+        if (res.statusCode() < 200 || res.statusCode() >= 300) {
+            throw new MemsysOAuthException(
+                    "token endpoint returned HTTP " + res.statusCode() + ": " + truncate(res.body(), 400));
+        }
+
+        try {
+            JsonNode root = mapper.readTree(res.body());
+            String access = root.path("access_token").asText(null);
+            String refresh = root.path("refresh_token").asText(null);
+            String idToken = root.path("id_token").asText(null);
+            long expiresIn = root.path("expires_in").asLong(3600);
+            String scope = root.path("scope").asText("");
+            if (access == null) {
+                throw new MemsysOAuthException("token response missing access_token: " + truncate(res.body(), 400));
+            }
+            ParsedIdToken id = parseIdToken(idToken);
+            return new TokenSet(
+                    access, refresh, idToken,
+                    Instant.now().plusSeconds(expiresIn),
+                    scope, id.sub(), id.displayName());
+        } catch (Exception e) {
+            if (e instanceof MemsysOAuthException me) throw me;
+            throw new MemsysOAuthException("token response parse failed: " + truncate(res.body(), 400), e);
+        }
+    }
+
+    private ParsedIdToken parseIdToken(String idToken) {
+        if (idToken == null || idToken.isBlank()) return new ParsedIdToken(null, null);
+        try {
+            String[] parts = idToken.split("\\.");
+            if (parts.length < 2) return new ParsedIdToken(null, null);
+            String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]), StandardCharsets.UTF_8);
+            JsonNode payload = mapper.readTree(payloadJson);
+            String sub = payload.path("sub").asText(null);
+            String email = payload.path("email").asText(null);
+            String name = payload.path("name").asText(null);
+            String display = name != null && !name.isBlank() ? name : email;
+            return new ParsedIdToken(sub, display);
+        } catch (Exception e) {
+            log.warn("[memsys-oauth] failed to parse id_token: {}", e.getMessage());
+            return new ParsedIdToken(null, null);
+        }
+    }
+
+    private HttpResponse<String> send(HttpRequest req) {
+        try {
+            return http.send(req, HttpResponse.BodyHandlers.ofString());
+        } catch (Exception e) {
+            throw new MemsysOAuthException("HTTP transport failure: " + e.getMessage(), e);
+        }
+    }
+
+
+    private static String truncate(String s, int max) {
+        if (s == null) return "";
+        return s.length() > max ? s.substring(0, max) + "…" : s;
+    }
+
+    public record TokenSet(
+            String accessToken,
+            String refreshToken,
+            String idToken,
+            Instant expiresAt,
+            String scope,
+            String subject,
+            String displayName
+    ) {}
+
+    private record ParsedIdToken(String sub, String displayName) {}
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/auth/UserMemsysConfig.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/auth/UserMemsysConfig.java
@@ -1,0 +1,98 @@
+package com.dtech.aitrader.v2.memsys.auth;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+/**
+ * Per-user memsys OAuth tokens. Mirrors the {@code user_kite_config} pattern.
+ *
+ * Populated by {@code GET /memsys/callback} after the Cognito-hosted Google OAuth
+ * flow succeeds. Used by the per-user {@link com.dtech.aitrader.v2.memsys.MemsysClient}
+ * factory to resolve the right bearer token + refresh-on-401.
+ *
+ * Tenant isolation: memsys decodes the JWT and resolves the tenant via tenant_identities
+ * (RLS-enforced). Algotrade never passes user_id in tool args — the access_token is
+ * sufficient identification. We still store the {@code memsysTenantSub} for audit so we
+ * know which memsys tenant this algotrade user is bound to.
+ */
+@Entity
+@Table(name = "user_memsys_config",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_memsys_user",
+                columnNames = {"user_id"}))
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserMemsysConfig {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** Algotrade user id. One memsys connection per algotrade user. */
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    /** Cognito 'sub' claim from the id_token — the memsys tenant identifier. */
+    @Column(name = "memsys_tenant_sub", length = 128)
+    private String memsysTenantSub;
+
+    /** Optional display name pulled from id_token (email or name claim). */
+    @Column(name = "display_name", length = 256)
+    private String displayName;
+
+    /** Encrypted access token (Cognito JWT). Short-lived (~1h by default). */
+    @Lob
+    @Column(name = "access_token_encrypted", columnDefinition = "TEXT")
+    private String accessTokenEncrypted;
+
+    /** Encrypted refresh token. Long-lived (default 30d on Cognito). */
+    @Lob
+    @Column(name = "refresh_token_encrypted", columnDefinition = "TEXT")
+    private String refreshTokenEncrypted;
+
+    /** Cognito client_id issued by DCR registration (per-user). Plaintext. */
+    @Column(name = "client_id", length = 128)
+    private String clientId;
+
+    /** Cognito client_secret issued by DCR registration (per-user). Encrypted. */
+    @Lob
+    @Column(name = "client_secret_encrypted", columnDefinition = "TEXT")
+    private String clientSecretEncrypted;
+
+    /** When the access token expires (server-time). Used to proactively refresh before MCP calls. */
+    @Column(name = "expires_at")
+    private Instant expiresAt;
+
+    /** Space-separated scopes granted at the time of issue (e.g. "memory.read memory.write"). */
+    @Column(name = "scopes", length = 512)
+    private String scopes;
+
+    /** Whether this config is the active one for the user. (One-active-per-user is the unique key.) */
+    @Column(name = "active", nullable = false)
+    private boolean active;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        if (createdAt == null) createdAt = now;
+        updatedAt = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+}

--- a/src/main/java/com/dtech/aitrader/v2/memsys/auth/UserMemsysConfigRepository.java
+++ b/src/main/java/com/dtech/aitrader/v2/memsys/auth/UserMemsysConfigRepository.java
@@ -1,0 +1,14 @@
+package com.dtech.aitrader.v2.memsys.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserMemsysConfigRepository extends JpaRepository<UserMemsysConfig, Long> {
+
+    Optional<UserMemsysConfig> findByUserIdAndActiveTrue(Long userId);
+
+    Optional<UserMemsysConfig> findByUserId(Long userId);
+}

--- a/src/main/java/com/dtech/aitrader/v2/orchestrator/OrchestratorV2Service.java
+++ b/src/main/java/com/dtech/aitrader/v2/orchestrator/OrchestratorV2Service.java
@@ -1,0 +1,298 @@
+package com.dtech.aitrader.v2.orchestrator;
+
+import com.dtech.aitrader.data.PlanGroup;
+import com.dtech.aitrader.data.PlanGroupState;
+import com.dtech.aitrader.data.WatchTrade;
+import com.dtech.aitrader.repository.PlanGroupRepository;
+import com.dtech.aitrader.repository.WatchTradeRepository;
+import com.dtech.aitrader.v2.agent.Agent1Client;
+import com.dtech.aitrader.v2.agent.Agent1Output;
+import com.dtech.aitrader.v2.scan.Agent1BundleBuilder;
+import com.dtech.aitrader.v2.scan.ScanContext;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Phase 3 orchestrator for AI Trader v2.
+ *
+ * Per-scan flow (per "Implementation Plan v1.2"):
+ *   1. Build the input bundle (drawings, annotations, journal, OHLC, candle patterns,
+ *      existing plan_groups). Memsys-sourced sections (playbook rules, active flags,
+ *      recently-resolved flags, user inputs since last scan) are empty until per-user
+ *      memsys OAuth lands — Agent 1 tolerates this.
+ *   2. Invoke Agent 1.
+ *   3. For each plan_group action in the response, dual-write to Postgres + memsys.
+ *      memsys side is stubbed for now (logs only); Postgres side persists fully so the
+ *      trader can review plan_groups + branches in DB / via UI today.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OrchestratorV2Service {
+
+    private static final String AGENT_VERSION = "v1.1";
+    private static final int DEFAULT_VALID_DAYS = 3;
+
+    private final Agent1BundleBuilder bundleBuilder;
+    private final Agent1Client agent1;
+    private final PlanGroupRepository planGroupRepository;
+    private final WatchTradeRepository watchTradeRepository;
+    private final ObjectMapper mapper;
+
+    @Transactional
+    public ScanResult scan(Long userId, String symbol, String timeframe, String tabUuid) {
+        long t0 = System.currentTimeMillis();
+        log.info("[v2-scan] start userId={} symbol={} timeframe={} tab={}",
+                userId, symbol, timeframe, tabUuid);
+
+        // 1. Bundle
+        Agent1BundleBuilder.Built built = bundleBuilder.build(userId, symbol, timeframe, tabUuid, AGENT_VERSION);
+        ScanContext ctx = built.scanContext();
+
+        // 2. Agent 1
+        Agent1Client.Agent1Invocation inv = agent1.invoke(userId, built.userMessage());
+        if (!inv.ok()) {
+            log.warn("[v2-scan] Agent 1 returned no parseable output for symbol={}; skipping action handlers", symbol);
+            return new ScanResult(ctx.getScanId(), 0, 0, 0, 0, 0, inv.response().costUsd().doubleValue(),
+                    inv.response().modelUsed(), "agent1-parse-fail");
+        }
+        Agent1Output out = inv.output();
+
+        // 3. Apply each plan_group action
+        int created = 0, updated = 0, superseded = 0, retired = 0;
+        for (Agent1Output.PlanGroupSpec pg : nullToEmpty(out.getPlan_groups())) {
+            String action = pg.getAction() == null ? "CREATE" : pg.getAction().toUpperCase();
+            try {
+                switch (action) {
+                    case "CREATE" -> { handleCreate(pg, userId, symbol, timeframe, ctx, inv); created++; }
+                    case "UPDATE" -> { handleUpdate(pg); updated++; }
+                    case "SUPERSEDE" -> { handleSupersede(pg, userId, symbol, timeframe, ctx, inv); superseded++; }
+                    case "RETIRE" -> { handleRetire(pg); retired++; }
+                    default -> log.warn("[v2-scan] unknown action '{}' on plan_group; skipping", action);
+                }
+            } catch (Exception e) {
+                log.error("[v2-scan] action {} failed on plan_group id={}: {}", action, pg.getId(), e.getMessage(), e);
+            }
+        }
+
+        int flagsEmitted = nullToEmpty(out.getFlags()).size();
+        if (flagsEmitted > 0) {
+            // TODO: write to memsys as type=question + ai-trader-flag once per-user auth lands.
+            // For today's "see trades" milestone, just log so the trader can review in console.
+            for (Agent1Output.FlagSpec f : out.getFlags()) {
+                log.info("[v2-scan][flag] severity={} category={} title={} details={}",
+                        f.getSeverity(), f.getCategory(), f.getTitle(), f.getDetails());
+            }
+        }
+
+        long elapsed = System.currentTimeMillis() - t0;
+        log.info("[v2-scan] done symbol={} created={} updated={} superseded={} retired={} flags={} elapsed={}ms cost=${} model={}",
+                symbol, created, updated, superseded, retired, flagsEmitted, elapsed, inv.response().costUsd(), inv.response().modelUsed());
+
+        return new ScanResult(ctx.getScanId(), created, updated, superseded, retired, flagsEmitted,
+                inv.response().costUsd().doubleValue(), inv.response().modelUsed(), null);
+    }
+
+    // ── action handlers ──────────────────────────────────────────────
+
+    private void handleCreate(Agent1Output.PlanGroupSpec spec, Long userId, String symbol, String timeframe,
+                              ScanContext ctx, Agent1Client.Agent1Invocation inv) {
+        PlanGroup pg = toEntity(spec, userId, symbol, timeframe, null, ctx, inv);
+        pg = planGroupRepository.save(pg);
+        log.info("[v2-scan][create] plan_group id={} branches={}", pg.getId(),
+                spec.getBranches() == null ? 0 : spec.getBranches().size());
+        persistBranches(spec, pg.getId(), symbol, userId);
+    }
+
+    private void handleUpdate(Agent1Output.PlanGroupSpec spec) {
+        if (spec.getId() == null) return;
+        Long pgId = tryParseLong(spec.getId());
+        if (pgId == null) return;
+        Optional<PlanGroup> existing = planGroupRepository.findById(pgId);
+        if (existing.isEmpty()) {
+            log.warn("[v2-scan][update] plan_group id={} not found; skipping", spec.getId());
+            return;
+        }
+        PlanGroup pg = existing.get();
+        if (spec.getUnderlying_hypothesis() != null) pg.setUnderlyingHypothesis(spec.getUnderlying_hypothesis());
+        if (spec.getStructural_validation() != null) pg.setStructuralValidation(spec.getStructural_validation());
+        if (spec.getDecision_zone() != null) {
+            pg.setDecisionZoneLow(toBigDecimal(spec.getDecision_zone().getLow()));
+            pg.setDecisionZoneHigh(toBigDecimal(spec.getDecision_zone().getHigh()));
+            pg.setDecisionZoneRationale(spec.getDecision_zone().getRationale());
+        }
+        if (spec.getValid_until() != null) pg.setValidUntil(parseIso(spec.getValid_until()));
+        planGroupRepository.save(pg);
+        log.info("[v2-scan][update] plan_group id={} applied", pgId);
+    }
+
+    private void handleSupersede(Agent1Output.PlanGroupSpec spec, Long userId, String symbol, String timeframe,
+                                 ScanContext ctx, Agent1Client.Agent1Invocation inv) {
+        Long oldId = tryParseLong(spec.getSupersedes_group_id());
+        if (oldId != null) {
+            planGroupRepository.findById(oldId).ifPresent(old -> {
+                old.setState(PlanGroupState.SUPERSEDED);
+                planGroupRepository.save(old);
+            });
+        }
+        PlanGroup pg = toEntity(spec, userId, symbol, timeframe, oldId, ctx, inv);
+        pg = planGroupRepository.save(pg);
+        log.info("[v2-scan][supersede] new plan_group id={} supersedes old id={}", pg.getId(), oldId);
+        persistBranches(spec, pg.getId(), symbol, userId);
+    }
+
+    private void handleRetire(Agent1Output.PlanGroupSpec spec) {
+        Long pgId = tryParseLong(spec.getId());
+        if (pgId == null) return;
+        planGroupRepository.findById(pgId).ifPresent(pg -> {
+            pg.setState(PlanGroupState.INVALIDATED);
+            planGroupRepository.save(pg);
+            log.info("[v2-scan][retire] plan_group id={} → INVALIDATED", pgId);
+        });
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    private void persistBranches(Agent1Output.PlanGroupSpec spec, Long planGroupId, String symbol, Long userId) {
+        if (spec.getBranches() == null) return;
+        for (Agent1Output.BranchSpec b : spec.getBranches()) {
+            try {
+                WatchTrade wt = WatchTrade.builder()
+                        .symbol(symbol)
+                        .sourceType("AI_TRADER_V2")
+                        .generatedAt(LocalDateTime.now())
+                        .generatedForDate(LocalDate.now())
+                        .direction(b.getDirection())
+                        .entry(toBigDecimal(midpoint(b.getEntry_zone())))
+                        .sl(toBigDecimal(b.getStop_loss()))
+                        .target(firstTarget(b.getTargets()))
+                        .confidence(b.getConfidence())
+                        .rr(computeRr(b))
+                        .triggerType("PATTERN_AT_ZONE")
+                        .triggerSpecJson(safeJson(buildTriggerSpec(b)))
+                        .rationale(b.getReasoning())
+                        .status("WATCHING")
+                        .userId(userId)
+                        .planGroupId(planGroupId)
+                        .branchLabel(b.getLabel())
+                        .siblingKillBranchIdsJson(safeJson(b.getSibling_kill_branches()))
+                        .decisionZoneLow(toBigDecimal(b.getEntry_zone() == null || b.getEntry_zone().isEmpty() ? null : b.getEntry_zone().get(0)))
+                        .decisionZoneHigh(toBigDecimal(b.getEntry_zone() == null || b.getEntry_zone().size() < 2 ? null : b.getEntry_zone().get(1)))
+                        .build();
+                watchTradeRepository.save(wt);
+            } catch (Exception e) {
+                log.error("[v2-scan] failed to persist branch label={}: {}", b.getLabel(), e.getMessage(), e);
+            }
+        }
+    }
+
+    private PlanGroup toEntity(Agent1Output.PlanGroupSpec spec, Long userId, String symbol, String timeframe,
+                                Long supersedesId, ScanContext ctx, Agent1Client.Agent1Invocation inv) {
+        return PlanGroup.builder()
+                .userId(userId)
+                .symbol(symbol)
+                .timeframe(timeframe)
+                .state(PlanGroupState.WATCHING)
+                .underlyingHypothesis(spec.getUnderlying_hypothesis())
+                .structuralValidation(spec.getStructural_validation())
+                .sourceDrawingIdsJson(safeJson(spec.getSource_drawing_ids()))
+                .sourceLabelIdsJson(safeJson(spec.getSource_label_ids()))
+                .sourceJournalNoteIdsJson(safeJson(spec.getSource_journal_note_ids()))
+                .playbookRulesAppliedJson(safeJson(spec.getPlaybook_rules_applied()))
+                .decisionZoneLow(spec.getDecision_zone() == null ? null : toBigDecimal(spec.getDecision_zone().getLow()))
+                .decisionZoneHigh(spec.getDecision_zone() == null ? null : toBigDecimal(spec.getDecision_zone().getHigh()))
+                .decisionZoneRationale(spec.getDecision_zone() == null ? null : spec.getDecision_zone().getRationale())
+                .validUntil(spec.getValid_until() != null
+                        ? parseIso(spec.getValid_until())
+                        : LocalDateTime.now().plusDays(DEFAULT_VALID_DAYS))
+                .supersedesGroupId(supersedesId)
+                .scanSummary(null) // populated at scan-level from agent output below
+                .agentVersion(AGENT_VERSION)
+                .rawAgentOutput(rawAgentOutput(inv))
+                .memsysMemoryId(null) // TODO: set after memsys-write lands
+                .build();
+    }
+
+    private String rawAgentOutput(Agent1Client.Agent1Invocation inv) {
+        try {
+            return mapper.writeValueAsString(inv.output());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static <T> List<T> nullToEmpty(List<T> list) { return list == null ? List.of() : list; }
+
+    private static Long tryParseLong(String s) {
+        if (s == null || s.isBlank()) return null;
+        try { return Long.parseLong(s); } catch (NumberFormatException e) { return null; }
+    }
+
+    private static BigDecimal toBigDecimal(Number n) {
+        return n == null ? null : BigDecimal.valueOf(n.doubleValue());
+    }
+
+    private static LocalDateTime parseIso(String s) {
+        try { return LocalDateTime.parse(s.length() > 19 ? s.substring(0, 19) : s); }
+        catch (Exception e) { return LocalDateTime.now().plusDays(DEFAULT_VALID_DAYS); }
+    }
+
+    private static Double midpoint(List<Double> zone) {
+        if (zone == null || zone.isEmpty()) return null;
+        if (zone.size() == 1) return zone.get(0);
+        return (zone.get(0) + zone.get(1)) / 2.0;
+    }
+
+    private static BigDecimal firstTarget(List<Double> targets) {
+        if (targets == null || targets.isEmpty()) return null;
+        return BigDecimal.valueOf(targets.get(0));
+    }
+
+    private static Double computeRr(Agent1Output.BranchSpec b) {
+        if (b.getStop_loss() == null || b.getTargets() == null || b.getTargets().isEmpty()) return null;
+        Double entry = midpoint(b.getEntry_zone());
+        if (entry == null) return null;
+        double risk = Math.abs(entry - b.getStop_loss());
+        if (risk < 1e-9) return null;
+        double reward = Math.abs(b.getTargets().get(0) - entry);
+        return reward / risk;
+    }
+
+    private java.util.Map<String, Object> buildTriggerSpec(Agent1Output.BranchSpec b) {
+        var m = new java.util.LinkedHashMap<String, Object>();
+        m.put("trigger_condition", b.getTrigger_condition());
+        m.put("required_pattern", b.getRequired_pattern());
+        m.put("invalidation_level", b.getInvalidation_level());
+        m.put("invalidation_rule", b.getInvalidation_rule());
+        m.put("targets", b.getTargets());
+        return m;
+    }
+
+    private String safeJson(Object o) {
+        if (o == null) return null;
+        try { return mapper.writeValueAsString(o); }
+        catch (Exception e) { return null; }
+    }
+
+    public record ScanResult(
+            String scanId,
+            int created,
+            int updated,
+            int superseded,
+            int retired,
+            int flagsEmitted,
+            double costUsd,
+            String modelUsed,
+            String error
+    ) {}
+}

--- a/src/main/java/com/dtech/aitrader/v2/routine/RoutinePromptSeeder.java
+++ b/src/main/java/com/dtech/aitrader/v2/routine/RoutinePromptSeeder.java
@@ -1,0 +1,100 @@
+package com.dtech.aitrader.v2.routine;
+
+import com.dtech.aitrader.v2.memsys.MemsysClient;
+import com.dtech.aitrader.v2.memsys.MemsysMemory;
+import com.dtech.aitrader.v2.memsys.MemsysWriteResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.stereotype.Service;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Publishes the nightly-review routine prompt to memsys at boot under the seed user's tenant.
+ *
+ * The routine prompt is the instruction set a claude.ai scheduled task fetches at fire time —
+ * it tells the AI how to review {@code ai-trader-scan-context} bundles and write back
+ * {@code ai-trader-plan-group} memories.
+ *
+ * Idempotent: if a memory with the same routine + version tags already exists for the seed
+ * user, this seeder no-ops. To roll out a new version, change the version constant and the
+ * markdown file; the old memory is left in place (caller can supersede if desired).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RoutinePromptSeeder {
+
+    private static final String ROUTINE_TAG = "routine:nightly-review";
+    private static final String VERSION_TAG = "version:v2";
+    private static final String RESOURCE_PATH = "classpath:routines/nightly-review-v2.md";
+
+    private final MemsysClient memsys;
+    private final ResourceLoader resourceLoader;
+
+    @Value("${routine.seed.enabled:true}")
+    private boolean enabled;
+
+    @Value("${routine.seed.user-id:1}")
+    private Long seedUserId;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void seedOnStartup() {
+        if (!enabled) {
+            log.info("[routine-seeder] disabled (routine.seed.enabled=false)");
+            return;
+        }
+        try {
+            String content = loadResource(RESOURCE_PATH);
+            List<MemsysMemory> candidates = memsys.searchMemories(
+                    seedUserId,
+                    "nightly-review routine prompt",
+                    List.of(ROUTINE_TAG, VERSION_TAG),
+                    "snippet",
+                    null, null, null, 10);
+            // memsys.searchMemories treats multiple tags as OR — post-filter for AND.
+            List<MemsysMemory> exact = candidates.stream()
+                    .filter(m -> m.getTags() != null
+                            && m.getTags().contains(ROUTINE_TAG)
+                            && m.getTags().contains(VERSION_TAG))
+                    .toList();
+            if (!exact.isEmpty()) {
+                log.info("[routine-seeder] memory already exists (id={}) for {} {} — skipping",
+                        exact.get(0).getId(), ROUTINE_TAG, VERSION_TAG);
+                return;
+            }
+            log.info("[routine-seeder] no existing memory found for {} {} ({} candidates matched only one tag) — publishing",
+                    ROUTINE_TAG, VERSION_TAG, candidates.size());
+            MemsysWriteResult result = memsys.writeMemory(
+                    seedUserId,
+                    content,
+                    "snippet",
+                    List.of("project:ai-trader-v2", ROUTINE_TAG, VERSION_TAG, "kind:prompt"),
+                    Map.of("seeded_at", Instant.now().toString(),
+                            "source", "algotrade-startup",
+                            "resource", RESOURCE_PATH),
+                    null,
+                    null);
+            log.info("[routine-seeder] published routine prompt id={} for userId={}",
+                    result.getId(), seedUserId);
+        } catch (Exception e) {
+            log.warn("[routine-seeder] seeding failed: {}", e.getMessage());
+        }
+    }
+
+    private String loadResource(String path) throws Exception {
+        Resource r = resourceLoader.getResource(path);
+        try (InputStream in = r.getInputStream()) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/src/main/java/com/dtech/aitrader/v2/scan/Agent1BundleBuilder.java
+++ b/src/main/java/com/dtech/aitrader/v2/scan/Agent1BundleBuilder.java
@@ -1,0 +1,249 @@
+package com.dtech.aitrader.v2.scan;
+
+import com.dtech.aitrader.annotation.dto.AnnotationBundleDto;
+import com.dtech.aitrader.annotation.dto.DrawingAnnotationDto;
+import com.dtech.aitrader.annotation.dto.JournalNoteDto;
+import com.dtech.aitrader.annotation.service.AnnotationBundleBuilder;
+import com.dtech.aitrader.data.PlanGroup;
+import com.dtech.aitrader.repository.PlanGroupRepository;
+import com.dtech.aitrader.data.PlanGroupState;
+import com.dtech.chartdata.model.OhlcBarDTO;
+import com.dtech.chartdata.service.ChartDataService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Assembles the input bundle for Agent 1 — produces the user-message string + a structured
+ * {@link ScanContext} record so the orchestrator can also push the scan context to memsys.
+ *
+ * Memsys-only sections (`<playbook_rules>`, `<active_flags>`, `<recently_resolved_flags>`,
+ * `<user_inputs_since_last_scan>`) are emitted as empty arrays until per-user memsys auth lands;
+ * Agent 1's prompt tolerates this (treats them as "no preloaded context" and proceeds with
+ * standard TA + the user's drawings/journal).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class Agent1BundleBuilder {
+
+    private static final int MAX_BARS = 250;
+    private static final int CANDLE_PATTERN_LOOKBACK = 5;
+
+    private final ChartDataService chartDataService;
+    private final AnnotationBundleBuilder annotationBundleBuilder;
+    private final PlanGroupRepository planGroupRepository;
+
+    /** Build the bundle. Side-effect-free; orchestrator decides what to do with the result. */
+    public Built build(Long userId, String symbol, String timeframe, String tabUuid, String agentVersion) {
+        Instant scanTimestamp = Instant.now();
+        String scanId = UUID.randomUUID().toString();
+
+        // Fetch bars (last 250 of the requested timeframe).
+        List<OhlcBarDTO> bars = chartDataService.getBars(symbol, timeframe, null, null, false);
+        if (bars == null) bars = List.of();
+        List<OhlcBarDTO> recentBars = bars.stream()
+                .skip(Math.max(0, bars.size() - MAX_BARS))
+                .collect(Collectors.toList());
+
+        // Candle pattern tags on the last 5 bars.
+        List<Map<String, Object>> candlePatterns = classifyLastN(recentBars, CANDLE_PATTERN_LOOKBACK);
+
+        // Annotations + journal — from existing AnnotationBundleBuilder. Drawing geometry comes from
+        // the saved drawings table (separately included as the `drawings` block). For the v2 bundle
+        // we surface the structured annotation intents + journal notes via the bundle DTO.
+        AnnotationBundleDto annBundle = (tabUuid != null && !tabUuid.isBlank())
+                ? annotationBundleBuilder.buildForLevels(userId, symbol, tabUuid)
+                : annotationBundleBuilder.buildForPattern(userId, symbol);
+
+        List<Map<String, Object>> annotationsBlock = annBundle.getAnnotations() == null
+                ? List.of()
+                : annBundle.getAnnotations().stream().map(Agent1BundleBuilder::annotationToMap).toList();
+        List<Map<String, Object>> journalBlock = annBundle.getJournalNotes() == null
+                ? List.of()
+                : annBundle.getJournalNotes().stream().map(Agent1BundleBuilder::journalToMap).toList();
+
+        // Existing WATCHING plan_groups for (user, symbol) — what Agent 1 may UPDATE/SUPERSEDE/RETIRE.
+        List<Map<String, Object>> existingGroups = planGroupRepository
+                .findByUserIdAndSymbolAndState(userId, symbol, PlanGroupState.WATCHING)
+                .stream().map(Agent1BundleBuilder::planGroupToMap).toList();
+
+        // Memsys-only sections — empty until per-user memsys OAuth lands.
+        List<Map<String, Object>> emptyList = List.of();
+        Map<String, Object> emptyMap = Map.of();
+
+        ScanContext ctx = ScanContext.builder()
+                .scanId(scanId)
+                .userId(userId)
+                .symbol(symbol)
+                .timeframe(timeframe)
+                .scanTimestamp(scanTimestamp)
+                .agentVersion(agentVersion)
+                .drawings(emptyList) // TODO: fetch from user_chart_state once drawings extractor exposes structured points
+                .annotations(annotationsBlock)
+                .pivotLabels(emptyList) // TODO: separate pivot-label store; treat as empty for now
+                .journalNotes(journalBlock)
+                .ohlcBars(barsToList(recentBars))
+                .indicators(emptyMap) // TODO: indicator snapshot — defer to next iteration
+                .candlePatterns(candlePatterns)
+                .playbookRules(emptyList) // memsys-blocked
+                .activeFlags(emptyList) // memsys-blocked
+                .recentlyResolvedFlags(emptyList) // memsys-blocked
+                .existingPlanGroups(existingGroups)
+                .userInputsSinceLastScan(emptyList) // memsys-blocked
+                .build();
+
+        String renderedPrompt = renderUserMessage(ctx);
+        ctx.setRenderedPromptText(renderedPrompt);
+
+        return new Built(ctx, renderedPrompt);
+    }
+
+    // ── render to <tagged> user-message string ───────────────────────
+
+    private String renderUserMessage(ScanContext ctx) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<symbol>").append(ctx.getSymbol()).append("</symbol>\n");
+        sb.append("<timeframe>").append(ctx.getTimeframe()).append("</timeframe>\n");
+        sb.append("<scan_timestamp>").append(
+                ctx.getScanTimestamp().atZone(ZoneId.of("Asia/Kolkata"))
+                        .format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+        ).append("</scan_timestamp>\n\n");
+
+        appendBlock(sb, "price_data", ctx.getOhlcBars());
+        appendBlock(sb, "indicators", ctx.getIndicators());
+        appendBlock(sb, "drawings", ctx.getDrawings());
+        appendBlock(sb, "labels", ctx.getPivotLabels());
+        appendBlock(sb, "annotations", ctx.getAnnotations());
+        appendBlock(sb, "journal_notes", ctx.getJournalNotes());
+        appendBlock(sb, "candle_patterns_last_5", ctx.getCandlePatterns());
+        appendBlock(sb, "playbook_rules", ctx.getPlaybookRules());
+        appendBlock(sb, "active_flags", ctx.getActiveFlags());
+        appendBlock(sb, "recently_resolved_flags", ctx.getRecentlyResolvedFlags());
+        appendBlock(sb, "existing_plan_groups", ctx.getExistingPlanGroups());
+        appendBlock(sb, "user_inputs_since_last_scan", ctx.getUserInputsSinceLastScan());
+
+        return sb.toString();
+    }
+
+    private void appendBlock(StringBuilder sb, String tag, Object body) {
+        sb.append("<").append(tag).append(">\n");
+        if (body == null) {
+            sb.append("[]\n");
+        } else if (body instanceof Collection<?> c && c.isEmpty()) {
+            sb.append("[]\n");
+        } else if (body instanceof Map<?, ?> m && m.isEmpty()) {
+            sb.append("{}\n");
+        } else {
+            sb.append(safeJson(body)).append("\n");
+        }
+        sb.append("</").append(tag).append(">\n\n");
+    }
+
+    private String safeJson(Object o) {
+        try {
+            return new com.fasterxml.jackson.databind.ObjectMapper().writeValueAsString(o);
+        } catch (Exception e) {
+            return "/* serialization failed: " + e.getMessage() + " */";
+        }
+    }
+
+    // ── candle pattern classification (mirrors AiAnalysePromptBuilder.classifyCandle) ──
+
+    private List<Map<String, Object>> classifyLastN(List<OhlcBarDTO> bars, int n) {
+        if (bars.size() < n + 1) return List.of();
+        List<Map<String, Object>> out = new ArrayList<>();
+        for (int offset = n - 1; offset >= 0; offset--) {
+            int curIdx = bars.size() - 1 - offset;
+            OhlcBarDTO prev = bars.get(curIdx - 1);
+            OhlcBarDTO cur = bars.get(curIdx);
+            List<String> tags = classifyCandle(prev, cur);
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("timestamp", Instant.ofEpochSecond(cur.getTime()).toString());
+            row.put("patterns", tags);
+            out.add(row);
+        }
+        return out;
+    }
+
+    private List<String> classifyCandle(OhlcBarDTO prev, OhlcBarDTO cur) {
+        List<String> tags = new ArrayList<>();
+        double bodyCur = Math.abs(cur.getClose() - cur.getOpen());
+        double rangeCur = Math.max(1e-9, cur.getHigh() - cur.getLow());
+        double upperWick = cur.getHigh() - Math.max(cur.getOpen(), cur.getClose());
+        double lowerWick = Math.min(cur.getOpen(), cur.getClose()) - cur.getLow();
+        boolean curGreen = cur.getClose() > cur.getOpen();
+        boolean prevGreen = prev.getClose() > prev.getOpen();
+
+        if (!curGreen && prevGreen
+                && cur.getOpen() >= prev.getClose()
+                && cur.getClose() <= prev.getOpen()) tags.add("bearish_engulfing");
+        if (curGreen && !prevGreen
+                && cur.getOpen() <= prev.getClose()
+                && cur.getClose() >= prev.getOpen()) tags.add("bullish_engulfing");
+        if (bodyCur < 0.35 * rangeCur && lowerWick > 1.8 * bodyCur && lowerWick > upperWick) tags.add("hammer");
+        if (bodyCur < 0.35 * rangeCur && upperWick > 1.8 * bodyCur && upperWick > lowerWick) tags.add("shooting_star");
+        if (bodyCur < 0.10 * rangeCur) tags.add("doji");
+        if (cur.getHigh() < prev.getHigh() && cur.getLow() > prev.getLow()) tags.add("inside_bar");
+
+        return tags;
+    }
+
+    // ── mappers ──────────────────────────────────────────────────────
+
+    private List<Map<String, Object>> barsToList(List<OhlcBarDTO> bars) {
+        List<Map<String, Object>> out = new ArrayList<>(bars.size());
+        for (OhlcBarDTO b : bars) {
+            Map<String, Object> row = new LinkedHashMap<>();
+            row.put("t", Instant.ofEpochSecond(b.getTime()).toString());
+            row.put("o", b.getOpen());
+            row.put("h", b.getHigh());
+            row.put("l", b.getLow());
+            row.put("c", b.getClose());
+            row.put("v", b.getVolume());
+            out.add(row);
+        }
+        return out;
+    }
+
+    private static Map<String, Object> annotationToMap(DrawingAnnotationDto a) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("id", "ann-" + a.getId());
+        m.put("intent", a.getIntent());
+        m.put("note", a.getNote());
+        m.put("weight", a.getWeight());
+        m.put("drawing_id", a.getDrawingId());
+        m.put("interval", a.getInterval());
+        m.put("params", a.getIntentParamsJson());
+        m.put("geometry", a.getGeometryJson());
+        return m;
+    }
+
+    private static Map<String, Object> journalToMap(JournalNoteDto n) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("id", "j-" + n.getId());
+        m.put("note_date", n.getNoteDate() == null ? null : n.getNoteDate().toString());
+        m.put("note", n.getNoteText());
+        return m;
+    }
+
+    private static Map<String, Object> planGroupToMap(PlanGroup pg) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("id", String.valueOf(pg.getId()));
+        m.put("state", pg.getState() == null ? null : pg.getState().name());
+        m.put("underlying_hypothesis", pg.getUnderlyingHypothesis());
+        m.put("decision_zone_low", pg.getDecisionZoneLow());
+        m.put("decision_zone_high", pg.getDecisionZoneHigh());
+        m.put("valid_until", pg.getValidUntil() == null ? null : pg.getValidUntil().toString());
+        return m;
+    }
+
+    /** Result of bundle assembly — both structured context and rendered user-message. */
+    public record Built(ScanContext scanContext, String userMessage) {}
+}

--- a/src/main/java/com/dtech/aitrader/v2/scan/ScanContext.java
+++ b/src/main/java/com/dtech/aitrader/v2/scan/ScanContext.java
@@ -1,0 +1,82 @@
+package com.dtech.aitrader.v2.scan;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The complete input bundle handed to Agent 1 for a single (user, symbol, timeframe) scan.
+ *
+ * Why this class exists: at scan time the orchestrator builds this bundle, sends it to
+ * Agent 1 as a prompt, and Agent 1 outputs plan_groups + flags. Agent 1's output gets
+ * mirrored to memsys as a "trade memory". But until now, Agent 1's INPUT was nowhere
+ * persisted — so when a human reviews a trade in Claude.ai chat with Opus, Opus has no
+ * way to see what Agent 1 actually saw. Was the drawn trendline in the bundle? Did the
+ * pivot label make it? What journal notes were active?
+ *
+ * Per user requirement (2026-05-18): this entire bundle goes to memsys as a
+ * "ai-trader-scan-context" memory, linked from each plan_group's metadata. Opus on
+ * review can fetch the scan context to see exactly what Agent 1 saw.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScanContext {
+    /** UUID we generate at scan-start so all related writes share a correlation id. */
+    private String scanId;
+    private Long userId;
+    private String symbol;
+    private String timeframe;
+    private Instant scanTimestamp;
+    private String agentVersion;
+
+    // ── what the agent reads ─────────────────────────────────────────
+
+    /** Drawings the trader has on this symbol's chart (TV save_load_adapter rows + intent annotations). */
+    private List<Map<String, Object>> drawings;
+
+    /** Per-drawing intent annotations (KEY_LEVEL / RETEST_ENTRY / etc.) — the structured intents. */
+    private List<Map<String, Object>> annotations;
+
+    /** Pivot labels (A, B, C, D, E) the trader has placed on the chart. */
+    private List<Map<String, Object>> pivotLabels;
+
+    /** Chronological free-form journal notes for this symbol (newest first). */
+    private List<Map<String, Object>> journalNotes;
+
+    /** Recent OHLC bars used to build the indicator + pattern view. */
+    private List<Map<String, Object>> ohlcBars;
+
+    /** Last-bar indicator snapshot (RSI, MACD, etc.) at the scan instant. */
+    private Map<String, Object> indicators;
+
+    /** Last-5-bar candle pattern classifications (bearish_engulfing, hammer, …). */
+    private List<Map<String, Object>> candlePatterns;
+
+    /** All active playbook rules loaded from memsys at scan-start. */
+    private List<Map<String, Object>> playbookRules;
+
+    /** Open flags on this symbol (BLOCKING / WARNING / INFO). */
+    private List<Map<String, Object>> activeFlags;
+
+    /** Flag resolutions from the last 30 days, included so Agent 1 doesn't re-raise dismissed concerns. */
+    private List<Map<String, Object>> recentlyResolvedFlags;
+
+    /** Existing WATCHING plan_groups for this (user, symbol). Agent 1 may UPDATE / SUPERSEDE / RETIRE them. */
+    private List<Map<String, Object>> existingPlanGroups;
+
+    /** Threaded chat comments the trader has added to active plan_groups since the previous scan. */
+    private List<Map<String, Object>> userInputsSinceLastScan;
+
+    /**
+     * The exact text of the prompt rendered from this bundle and sent to Agent 1.
+     * Stored verbatim so we have a perfect replay of what Agent 1 read.
+     */
+    private String renderedPromptText;
+}

--- a/src/main/java/com/dtech/aitrader/v2/scan/ScanContextMarkdown.java
+++ b/src/main/java/com/dtech/aitrader/v2/scan/ScanContextMarkdown.java
@@ -37,20 +37,19 @@ public class ScanContextMarkdown {
         appendListSection(sb, "Pivot labels", ctx.getPivotLabels());
         appendListSection(sb, "Journal notes (newest first)", ctx.getJournalNotes());
         appendListSection(sb, "Candle patterns (last 5 bars)", ctx.getCandlePatterns());
-        appendMapSection(sb, "Last-bar indicators", ctx.getIndicators());
         appendListSection(sb, "Playbook rules in scope", ctx.getPlaybookRules());
         appendListSection(sb, "Active flags", ctx.getActiveFlags());
         appendListSection(sb, "Recently resolved flags (last 30d)", ctx.getRecentlyResolvedFlags());
         appendListSection(sb, "Existing plan groups (WATCHING)", ctx.getExistingPlanGroups());
         appendListSection(sb, "User inputs since last scan", ctx.getUserInputsSinceLastScan());
-        appendListSection(sb, "OHLC bars", ctx.getOhlcBars());
 
-        if (ctx.getRenderedPromptText() != null && !ctx.getRenderedPromptText().isBlank()) {
-            sb.append("---\n\n## Rendered prompt sent to Agent 1\n\n```\n");
-            sb.append(ctx.getRenderedPromptText());
-            if (!ctx.getRenderedPromptText().endsWith("\n")) sb.append("\n");
-            sb.append("```\n");
-        }
+        sb.append("---\n\n");
+        sb.append("## Market data — fetch fresh\n\n");
+        sb.append("This bundle deliberately omits OHLC bars and indicators.\n");
+        sb.append("Routine consumer should call **Kite MCP** at run time:\n");
+        sb.append("- `kite_get_historical_data` for bars (use the symbol + timeframe above)\n");
+        sb.append("- `kite_get_quote` for live LTP\n");
+        sb.append("- `kite_get_holdings` / `kite_get_positions` for portfolio context\n");
 
         return sb.toString();
     }

--- a/src/main/java/com/dtech/aitrader/v2/scan/ScanContextMarkdown.java
+++ b/src/main/java/com/dtech/aitrader/v2/scan/ScanContextMarkdown.java
@@ -1,0 +1,93 @@
+package com.dtech.aitrader.v2.scan;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Renders a {@link ScanContext} as a Markdown document for memsys storage.
+ *
+ * Output is structured so a reviewing model (Opus on claude.ai chat) can scan it and
+ * answer questions like "did Agent 1 see the trendline drawn from 1532 → 1611?",
+ * "what was the RSI at scan time?", "was there a journal entry mentioning third wave?".
+ */
+@Component
+@RequiredArgsConstructor
+public class ScanContextMarkdown {
+
+    private final ObjectMapper mapper;
+
+    public String render(ScanContext ctx) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("# AI Trader v2 — Scan Context\n\n");
+        sb.append("Scan id: `").append(safe(ctx.getScanId())).append("`  \n");
+        sb.append("Symbol: **").append(safe(ctx.getSymbol())).append("** · ");
+        sb.append("Timeframe: ").append(safe(ctx.getTimeframe())).append("  \n");
+        sb.append("Scan timestamp: ").append(safe(ctx.getScanTimestamp())).append("  \n");
+        sb.append("Agent version: ").append(safe(ctx.getAgentVersion())).append("  \n");
+        sb.append("User id: ").append(safe(ctx.getUserId())).append("\n\n");
+
+        appendListSection(sb, "Drawings", ctx.getDrawings());
+        appendListSection(sb, "Annotations (intent overlays)", ctx.getAnnotations());
+        appendListSection(sb, "Pivot labels", ctx.getPivotLabels());
+        appendListSection(sb, "Journal notes (newest first)", ctx.getJournalNotes());
+        appendListSection(sb, "Candle patterns (last 5 bars)", ctx.getCandlePatterns());
+        appendMapSection(sb, "Last-bar indicators", ctx.getIndicators());
+        appendListSection(sb, "Playbook rules in scope", ctx.getPlaybookRules());
+        appendListSection(sb, "Active flags", ctx.getActiveFlags());
+        appendListSection(sb, "Recently resolved flags (last 30d)", ctx.getRecentlyResolvedFlags());
+        appendListSection(sb, "Existing plan groups (WATCHING)", ctx.getExistingPlanGroups());
+        appendListSection(sb, "User inputs since last scan", ctx.getUserInputsSinceLastScan());
+        appendListSection(sb, "OHLC bars", ctx.getOhlcBars());
+
+        if (ctx.getRenderedPromptText() != null && !ctx.getRenderedPromptText().isBlank()) {
+            sb.append("---\n\n## Rendered prompt sent to Agent 1\n\n```\n");
+            sb.append(ctx.getRenderedPromptText());
+            if (!ctx.getRenderedPromptText().endsWith("\n")) sb.append("\n");
+            sb.append("```\n");
+        }
+
+        return sb.toString();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────
+
+    private void appendListSection(StringBuilder sb, String title, List<Map<String, Object>> items) {
+        sb.append("## ").append(title).append("\n\n");
+        if (items == null || items.isEmpty()) {
+            sb.append("_(none)_\n\n");
+            return;
+        }
+        sb.append("```json\n");
+        sb.append(toPretty(items));
+        sb.append("\n```\n\n");
+    }
+
+    private void appendMapSection(StringBuilder sb, String title, Map<String, Object> map) {
+        sb.append("## ").append(title).append("\n\n");
+        if (map == null || map.isEmpty()) {
+            sb.append("_(none)_\n\n");
+            return;
+        }
+        sb.append("```json\n");
+        sb.append(toPretty(map));
+        sb.append("\n```\n\n");
+    }
+
+    private String toPretty(Object o) {
+        try {
+            return mapper.copy().enable(SerializationFeature.INDENT_OUTPUT).writeValueAsString(o);
+        } catch (JsonProcessingException e) {
+            return "/* failed to serialize: " + e.getMessage() + " */";
+        }
+    }
+
+    private static String safe(Object v) {
+        return v == null ? "_(unset)_" : String.valueOf(v);
+    }
+}

--- a/src/main/java/com/dtech/aitrader/v2/scan/ScanContextWriter.java
+++ b/src/main/java/com/dtech/aitrader/v2/scan/ScanContextWriter.java
@@ -32,6 +32,8 @@ import java.util.Map;
 @Slf4j
 public class ScanContextWriter {
 
+    private static final int MEMSYS_MAX_CONTENT_CHARS = 32_500; // leave a small buffer below 32768
+
     private final MemsysClient memsys;
     private final ScanContextMarkdown markdown;
 
@@ -45,6 +47,14 @@ public class ScanContextWriter {
      */
     public String write(ScanContext ctx) {
         String body = markdown.render(ctx);
+        int originalLen = body.length();
+        if (body.length() > MEMSYS_MAX_CONTENT_CHARS) {
+            body = body.substring(0, MEMSYS_MAX_CONTENT_CHARS)
+                    + "\n\n…[truncated by ScanContextWriter — " + originalLen
+                    + " chars → " + MEMSYS_MAX_CONTENT_CHARS + "]";
+            log.warn("[scan-context] bundle for symbol={} truncated: {} → {} chars",
+                    ctx.getSymbol(), originalLen, body.length());
+        }
         List<String> tags = List.of(
                 "ai-trader-scan-context",
                 "ai-trader-v2",
@@ -64,13 +74,13 @@ public class ScanContextWriter {
 
         try {
             MemsysWriteResult result = memsys.writeMemory(
-                    body, "fact", tags, metadata, /*parentId*/ null, /*supersedes*/ null);
-            log.info("[scan-context] wrote memsys memory id={} for scan_id={} symbol={}",
-                    result.getId(), ctx.getScanId(), ctx.getSymbol());
+                    ctx.getUserId(), body, "fact", tags, metadata, /*parentId*/ null, /*supersedes*/ null);
+            log.info("[scan-context] wrote memsys memory id={} for scan_id={} symbol={} body_chars={}",
+                    result.getId(), ctx.getScanId(), ctx.getSymbol(), body.length());
             return result.getId();
         } catch (Exception e) {
-            log.error("[scan-context] failed to write to memsys for scan_id={} symbol={}: {}",
-                    ctx.getScanId(), ctx.getSymbol(), e.getMessage());
+            log.error("[scan-context] failed to write to memsys for scan_id={} symbol={} body_chars={}: {}",
+                    ctx.getScanId(), ctx.getSymbol(), originalLen, e.getMessage());
             return null;
         }
     }
@@ -79,11 +89,11 @@ public class ScanContextWriter {
      * After plan_groups are created, link them back into the scan-context memory's metadata
      * so morning review can navigate from a scan to its trades. Best-effort; logs and continues.
      */
-    public void linkPlanGroups(String scanContextMemoryId, List<Long> planGroupIds) {
+    public void linkPlanGroups(Long userId, String scanContextMemoryId, List<Long> planGroupIds) {
         if (scanContextMemoryId == null || scanContextMemoryId.isBlank()) return;
         try {
             Map<String, Object> patch = Map.of("plan_group_ids", planGroupIds);
-            memsys.updateMemory(scanContextMemoryId, null, null, patch, null);
+            memsys.updateMemory(userId, scanContextMemoryId, null, null, patch, null);
         } catch (Exception e) {
             log.warn("[scan-context] failed to back-link plan_groups to {}: {}",
                     scanContextMemoryId, e.getMessage());

--- a/src/main/java/com/dtech/aitrader/v2/scan/ScanContextWriter.java
+++ b/src/main/java/com/dtech/aitrader/v2/scan/ScanContextWriter.java
@@ -1,0 +1,96 @@
+package com.dtech.aitrader.v2.scan;
+
+import com.dtech.aitrader.v2.memsys.MemsysClient;
+import com.dtech.aitrader.v2.memsys.MemsysWriteResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Pushes a {@link ScanContext} to memsys as a single `ai-trader-scan-context` memory,
+ * returning the memory id so the orchestrator can stash it on each plan_group it then
+ * creates (via plan_group metadata or a separate column).
+ *
+ * Tag layout:
+ *   ai-trader-scan-context           ← primary discriminator
+ *   ai-trader-v2
+ *   symbol-{TICKER}                  ← always
+ *   timeframe-{TF}                   ← e.g. timeframe-1D
+ *   scan-id-{uuid}                   ← so all scans for one (user, symbol) can be threaded
+ *   date-YYYY-MM-DD                  ← scan date
+ *
+ * Metadata:
+ *   scan_id, user_id, symbol, timeframe, agent_version
+ *   plan_group_ids: List<Long>       ← filled in by orchestrator AFTER it knows the ids
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ScanContextWriter {
+
+    private final MemsysClient memsys;
+    private final ScanContextMarkdown markdown;
+
+    /**
+     * Writes the scan context to memsys at scan-START (before Agent 1 fires). Returns the
+     * memory id so the orchestrator can link plan_groups back via metadata afterwards.
+     * <p>
+     * If memsys is unavailable, returns null and logs — the rest of the scan should not
+     * be blocked by a memsys write failure (Agent 1 still runs; we just lose the audit trail
+     * for this scan).
+     */
+    public String write(ScanContext ctx) {
+        String body = markdown.render(ctx);
+        List<String> tags = List.of(
+                "ai-trader-scan-context",
+                "ai-trader-v2",
+                "symbol-" + safe(ctx.getSymbol()),
+                "timeframe-" + safe(ctx.getTimeframe()),
+                "scan-id-" + safe(ctx.getScanId()),
+                "date-" + (ctx.getScanTimestamp() == null ? "unknown"
+                        : ctx.getScanTimestamp().toString().substring(0, 10))
+        );
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        metadata.put("scan_id", ctx.getScanId());
+        metadata.put("user_id", ctx.getUserId());
+        metadata.put("symbol", ctx.getSymbol());
+        metadata.put("timeframe", ctx.getTimeframe());
+        metadata.put("agent_version", ctx.getAgentVersion());
+        metadata.put("scan_timestamp", String.valueOf(ctx.getScanTimestamp()));
+
+        try {
+            MemsysWriteResult result = memsys.writeMemory(
+                    body, "fact", tags, metadata, /*parentId*/ null, /*supersedes*/ null);
+            log.info("[scan-context] wrote memsys memory id={} for scan_id={} symbol={}",
+                    result.getId(), ctx.getScanId(), ctx.getSymbol());
+            return result.getId();
+        } catch (Exception e) {
+            log.error("[scan-context] failed to write to memsys for scan_id={} symbol={}: {}",
+                    ctx.getScanId(), ctx.getSymbol(), e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * After plan_groups are created, link them back into the scan-context memory's metadata
+     * so morning review can navigate from a scan to its trades. Best-effort; logs and continues.
+     */
+    public void linkPlanGroups(String scanContextMemoryId, List<Long> planGroupIds) {
+        if (scanContextMemoryId == null || scanContextMemoryId.isBlank()) return;
+        try {
+            Map<String, Object> patch = Map.of("plan_group_ids", planGroupIds);
+            memsys.updateMemory(scanContextMemoryId, null, null, patch, null);
+        } catch (Exception e) {
+            log.warn("[scan-context] failed to back-link plan_groups to {}: {}",
+                    scanContextMemoryId, e.getMessage());
+        }
+    }
+
+    private static String safe(Object o) {
+        return o == null ? "unknown" : String.valueOf(o);
+    }
+}

--- a/src/main/java/com/dtech/aitrader/v2/web/AiTraderV2Controller.java
+++ b/src/main/java/com/dtech/aitrader/v2/web/AiTraderV2Controller.java
@@ -5,6 +5,7 @@ import com.dtech.aitrader.data.PlanGroupState;
 import com.dtech.aitrader.data.WatchTrade;
 import com.dtech.aitrader.repository.PlanGroupRepository;
 import com.dtech.aitrader.repository.WatchTradeRepository;
+import com.dtech.aitrader.v2.batch.NightlyBundleDumpService;
 import com.dtech.aitrader.v2.orchestrator.OrchestratorV2Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -27,6 +28,7 @@ import java.util.Map;
 public class AiTraderV2Controller {
 
     private final OrchestratorV2Service orchestrator;
+    private final NightlyBundleDumpService nightlyBatch;
     private final PlanGroupRepository planGroupRepository;
     private final WatchTradeRepository watchTradeRepository;
 
@@ -42,6 +44,21 @@ public class AiTraderV2Controller {
             return ResponseEntity.ok(result);
         } catch (Exception e) {
             log.error("v2 scan failed for symbol={}: {}", symbol, e.getMessage(), e);
+            return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    /**
+     * Fires the nightly bundle-dump batch on demand. Same code path as the scheduled cron;
+     * useful for testing / running a fresh batch before the next 22:00 IST cycle.
+     */
+    @PostMapping("/batch/run")
+    public ResponseEntity<?> runBatch(Authentication auth) {
+        try {
+            NightlyBundleDumpService.Summary summary = nightlyBatch.runManual();
+            return ResponseEntity.ok(summary);
+        } catch (Exception e) {
+            log.error("manual v2 batch fire failed: {}", e.getMessage(), e);
             return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
         }
     }

--- a/src/main/java/com/dtech/aitrader/v2/web/AiTraderV2Controller.java
+++ b/src/main/java/com/dtech/aitrader/v2/web/AiTraderV2Controller.java
@@ -1,0 +1,112 @@
+package com.dtech.aitrader.v2.web;
+
+import com.dtech.aitrader.data.PlanGroup;
+import com.dtech.aitrader.data.PlanGroupState;
+import com.dtech.aitrader.data.WatchTrade;
+import com.dtech.aitrader.repository.PlanGroupRepository;
+import com.dtech.aitrader.repository.WatchTradeRepository;
+import com.dtech.aitrader.v2.orchestrator.OrchestratorV2Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Endpoints to fire an Agent 1 scan and read back the resulting plan_groups + branches.
+ * Browser-friendly so the trader can hit them from /ai-trader during the build phase.
+ */
+@RestController
+@RequestMapping("/api/ai-trader-v2")
+@RequiredArgsConstructor
+@Slf4j
+public class AiTraderV2Controller {
+
+    private final OrchestratorV2Service orchestrator;
+    private final PlanGroupRepository planGroupRepository;
+    private final WatchTradeRepository watchTradeRepository;
+
+    @PostMapping("/scan")
+    public ResponseEntity<?> scan(
+            @RequestParam String symbol,
+            @RequestParam(defaultValue = "OneHour") String timeframe,
+            @RequestParam(required = false) String tabUuid,
+            Authentication auth) {
+        Long userId = extractUserId(auth);
+        try {
+            OrchestratorV2Service.ScanResult result = orchestrator.scan(userId, symbol, timeframe, tabUuid);
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            log.error("v2 scan failed for symbol={}: {}", symbol, e.getMessage(), e);
+            return ResponseEntity.status(500).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/plan-groups")
+    public ResponseEntity<?> listPlanGroups(
+            @RequestParam(required = false) String symbol,
+            @RequestParam(required = false) String state,
+            Authentication auth) {
+        Long userId = extractUserId(auth);
+        List<PlanGroup> rows;
+        if (symbol != null && state != null) {
+            rows = planGroupRepository.findByUserIdAndSymbolAndState(
+                    userId, symbol.toUpperCase(), PlanGroupState.valueOf(state.toUpperCase()));
+        } else if (symbol != null) {
+            rows = planGroupRepository.findByUserIdAndSymbolAndState(
+                    userId, symbol.toUpperCase(), PlanGroupState.WATCHING);
+        } else if (state != null) {
+            rows = planGroupRepository.findByUserIdAndStateOrderByUpdatedAtDesc(
+                    userId, PlanGroupState.valueOf(state.toUpperCase()));
+        } else {
+            rows = planGroupRepository.findByUserIdAndStateOrderByUpdatedAtDesc(userId, PlanGroupState.WATCHING);
+        }
+        return ResponseEntity.ok(rows.stream().map(this::toDto).toList());
+    }
+
+    @GetMapping("/plan-groups/{id}")
+    public ResponseEntity<?> getPlanGroup(@PathVariable Long id, Authentication auth) {
+        Long userId = extractUserId(auth);
+        return planGroupRepository.findById(id)
+                .filter(pg -> pg.getUserId().equals(userId))
+                .map(pg -> {
+                    Map<String, Object> dto = toDto(pg);
+                    List<WatchTrade> branches = watchTradeRepository.findAll().stream()
+                            .filter(wt -> id.equals(wt.getPlanGroupId()))
+                            .toList();
+                    dto.put("branches", branches);
+                    return ResponseEntity.ok(dto);
+                })
+                .orElseGet(() -> ResponseEntity.status(404).body(null));
+    }
+
+    private Map<String, Object> toDto(PlanGroup pg) {
+        Map<String, Object> dto = new LinkedHashMap<>();
+        dto.put("id", pg.getId());
+        dto.put("symbol", pg.getSymbol());
+        dto.put("timeframe", pg.getTimeframe());
+        dto.put("state", pg.getState());
+        dto.put("underlying_hypothesis", pg.getUnderlyingHypothesis());
+        dto.put("structural_validation", pg.getStructuralValidation());
+        dto.put("decision_zone", Map.of(
+                "low", pg.getDecisionZoneLow(),
+                "high", pg.getDecisionZoneHigh(),
+                "rationale", pg.getDecisionZoneRationale()
+        ));
+        dto.put("valid_until", pg.getValidUntil());
+        dto.put("created_at", pg.getCreatedAt());
+        dto.put("agent_version", pg.getAgentVersion());
+        return dto;
+    }
+
+    private Long extractUserId(Authentication auth) {
+        if (auth == null || auth.getName() == null) {
+            throw new IllegalStateException("User not authenticated");
+        }
+        return 1L; // matches existing pattern in AiLevelsController
+    }
+}

--- a/src/main/java/com/dtech/kitecon/auth/SecurityConfig.java
+++ b/src/main/java/com/dtech/kitecon/auth/SecurityConfig.java
@@ -55,6 +55,11 @@ public class SecurityConfig {
                         // Kite connect redirect — browser navigation, no JWT
                         .requestMatchers("/api/admin/kite-configs/*/connect").permitAll()
 
+                        // memsys OAuth callback — Cognito redirects here with no JWT
+                        .requestMatchers("/memsys/callback").permitAll()
+                        // memsys connect redirect — browser navigation, no JWT
+                        .requestMatchers("/api/admin/memsys-configs/*/connect").permitAll()
+
                         // SPA frontend routes — served as index.html, React Router handles them.
                         // ALL non-API GET paths must be permitAll so the browser can load index.html
                         // even when unauthenticated; the React app itself enforces auth via ProtectedRoute.
@@ -69,6 +74,7 @@ public class SecurityConfig {
                                 "/settings",
                                 "/admin/kite-config",
                                 "/admin/groups",
+                                "/admin/memsys",
                                 "/debug/elliott",
                                 "/elliott-screener/*/status"
                         ).permitAll()

--- a/src/main/java/com/dtech/kitecon/kite/repository/UserKiteConfigRepository.java
+++ b/src/main/java/com/dtech/kitecon/kite/repository/UserKiteConfigRepository.java
@@ -3,8 +3,10 @@ package com.dtech.kitecon.kite.repository;
 import com.dtech.kitecon.kite.entity.UserKiteConfig;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.util.Optional;
 
 public interface UserKiteConfigRepository extends JpaRepository<UserKiteConfig, Long> {
     List<UserKiteConfig> findByPlatformUserId(Long platformUserId);
     List<UserKiteConfig> findByActiveTrue();
+    Optional<UserKiteConfig> findFirstByPlatformUserIdAndActiveTrue(Long platformUserId);
 }

--- a/src/main/java/com/dtech/kitecon/service/copilot/UserAiProviderService.java
+++ b/src/main/java/com/dtech/kitecon/service/copilot/UserAiProviderService.java
@@ -88,6 +88,26 @@ public class UserAiProviderService {
         return providerRepository.findByUserIdAndActiveTrue(userId);
     }
 
+    /**
+     * Finds the first provider for this user whose base URL contains the substring (e.g. "anthropic.com"),
+     * regardless of active flag. Used by per-role provider routing (Agent 1 wants Anthropic even when the
+     * user's default active provider is something else).
+     */
+    public Optional<UserAiProvider> findByUserIdAndBaseUrlContains(Long userId, String substr) {
+        if (substr == null || substr.isBlank()) return Optional.empty();
+        return listProviders(userId).stream()
+                .filter(p -> p.getBaseUrl() != null && p.getBaseUrl().contains(substr))
+                .findFirst();
+    }
+
+    /** Returns the decrypted key for a specific provider entity. */
+    public Optional<String> getDecryptedApiKey(UserAiProvider provider) {
+        if (provider == null) return Optional.empty();
+        String enc = provider.getApiKeyEncrypted();
+        if (enc == null || enc.isBlank()) return Optional.empty();
+        return Optional.of(encryptionService.decrypt(enc));
+    }
+
     /** Returns the decrypted API key for the active provider, or empty. */
     public Optional<String> getActiveApiKey(Long userId) {
         return getActiveProvider(userId)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -188,3 +188,10 @@ screener.scheduler.hourly-cron=0 0 9-15 * * MON-FRI
 pattern.model=claude-sonnet-4-5-20250929
 pattern.enabled=false
 paper_trade.enabled=false
+
+# AI Trader v2 — memsys MCP client
+# Endpoint defaults to the user's hosted memsys instance. Override per environment.
+# Bearer token is intentionally blank by default — set in env-specific overrides
+# or as an environment variable MEMSYS_BEARER_TOKEN.
+memsys.endpoint=https://memsys.dheemantech.in/mcp
+memsys.bearer-token=${MEMSYS_BEARER_TOKEN:}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -195,3 +195,27 @@ paper_trade.enabled=false
 # or as an environment variable MEMSYS_BEARER_TOKEN.
 memsys.endpoint=https://memsys.dheemantech.in/mcp
 memsys.bearer-token=${MEMSYS_BEARER_TOKEN:}
+
+# AI Trader v2 — Agent 1 (Strategic Planner) provider override
+# When agent1.api-key is set, Agent 1 routes through agent1.base-url with agent1.model,
+# regardless of the user's default provider (which may be Nemotron etc.).
+# Leave blank to fall back to the user's resolved provider.
+agent1.model=claude-sonnet-4-5-20250929
+agent1.api-key=${ANTHROPIC_API_KEY:}
+agent1.base-url=https://api.anthropic.com/v1
+agent1.max-tokens=4096
+
+# AI Trader v2 — nightly bundle-dump batch
+# This batch does NOT call an LLM. It builds Agent 1 input bundles for every FNO symbol
+# and writes them to memsys as ai-trader-scan-context memories. A claude.ai scheduled
+# routine then reads tonight's bundles and emits trade memories back (using Max-plan
+# capacity — zero per-token cost on the algotrade side).
+#
+# Default cron: 22:00 IST weekdays. Override per environment as needed.
+agent1.batch.enabled=false
+agent1.batch.cron=0 0 22 * * MON-FRI
+agent1.batch.user-id=1
+agent1.batch.timeframe=OneHour
+agent1.batch.index=FNO
+agent1.batch.skip-empty-context=true
+agent1.batch.max-symbols=500

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -196,6 +196,16 @@ paper_trade.enabled=false
 memsys.endpoint=https://memsys.dheemantech.in/mcp
 memsys.bearer-token=${MEMSYS_BEARER_TOKEN:}
 
+# memsys OAuth (per-user, Cognito DCR). Run POST /api/admin/memsys/dcr-register once to
+# obtain client_id + client_secret, then set the two env vars below and restart.
+memsys.oauth.client-id=${MEMSYS_OAUTH_CLIENT_ID:}
+memsys.oauth.client-secret=${MEMSYS_OAUTH_CLIENT_SECRET:}
+memsys.oauth.authorize-url=https://memauth.dheemantech.in/login
+memsys.oauth.token-url=https://memauth.dheemantech.in/oauth2/token
+memsys.oauth.dcr-url=https://memsys.dheemantech.in/oauth/register
+memsys.oauth.redirect-uri=https://tradeapi.dheemantech.in/memsys/callback
+memsys.oauth.scopes=https://memsys.dheemantech.in/memory.read https://memsys.dheemantech.in/memory.write
+
 # AI Trader v2 — Agent 1 (Strategic Planner) provider override
 # When agent1.api-key is set, Agent 1 routes through agent1.base-url with agent1.model,
 # regardless of the user's default provider (which may be Nemotron etc.).
@@ -214,8 +224,14 @@ agent1.max-tokens=4096
 # Default cron: 22:00 IST weekdays. Override per environment as needed.
 agent1.batch.enabled=false
 agent1.batch.cron=0 0 22 * * MON-FRI
-agent1.batch.user-id=1
+agent1.batch.user-id=4
 agent1.batch.timeframe=OneHour
 agent1.batch.index=FNO
 agent1.batch.skip-empty-context=true
 agent1.batch.max-symbols=500
+
+# Routine prompt seeder — publishes the nightly-review runbook to memsys at boot
+# for the seed user's tenant. Idempotent: skips if (routine:nightly-review + version:vN)
+# already exists in that tenant.
+routine.seed.enabled=true
+routine.seed.user-id=4

--- a/src/main/resources/prompts/agent1_v1_1.txt
+++ b/src/main/resources/prompts/agent1_v1_1.txt
@@ -1,0 +1,206 @@
+You are the Strategic Planner, an AI agent for an Indian equity trader who uses Elliott Wave theory, classical chart patterns, and a personally-maintained playbook. You analyze stocks based on the user's drawings, pivot labels, structured annotations, journal notes, and prior chat-based discussion. You emit conditional trade plans tied to triggers, and flags for concerns that need user review.
+
+You are NOT a chatbot. Your only output is a single JSON object matching the schema below. No prose outside JSON. No markdown wrappers.
+
+# YOUR JOB
+
+For each symbol provided in the input bundle, do the following in order:
+
+1. Read the user's intent from drawings, pivot labels, structured annotations, journal notes, AND any threaded comments from prior chat reviews (in `<user_inputs_since_last_scan>`).
+2. Identify the chart pattern(s) implied — triangle, ending diagonal, impulse wave, channel, double top, etc. There may be more than one valid interpretation.
+3. Consult `<playbook_rules>` (preloaded by orchestrator) for relevant rules for each identified pattern type.
+4. Consult `<recently_resolved_flags>` to avoid re-raising dismissed concerns and to apply user's resolution reasoning.
+5. Validate the structure against actual price action.
+6. Identify decision zones where the structure can bifurcate into multiple valid resolutions.
+7. If `<existing_plan_groups>` has active groups for this symbol, decide whether to: (a) leave them as-is, (b) update them (if user inputs warrant), (c) supersede them (if hypothesis materially changed), or (d) let orchestrator expire them naturally.
+8. Construct plan groups — one per coherent underlying hypothesis — and within each, branches for each valid actionable resolution.
+9. Filter branches to ONLY those whose triggers could plausibly fire within 2-3 days.
+10. Emit flags for inferences made, geometric concerns, rule violations, stale drawings, contradictions, or anything the user should review.
+11. Return a single JSON object with `plan_groups[]`, `flags[]`, and supporting fields.
+
+# CORE PRINCIPLES (apply without exception)
+
+## Principle 1: Labels = Intent, Pivots = Truth
+
+The user's labels (A, B, C, D, E, etc.) declare which swing points they intend to use as structure pivots. The actual swing highs and lows in price data are geometric truth. Reconcile them as follows:
+
+- If each label corresponds to a real swing pivot in the price data within tolerance (use playbook tolerance rule if available — typically PB-004 family; otherwise ~0.5× ATR proximity), labels stand.
+- If a label is positioned at a level price never reached → hard reject the structure. Emit a BLOCKING flag, no plan_group.
+- If there are significant intermediate pivots in price data that the user didn't label AND they materially change the implied trendlines, emit a flag. Severity: BLOCKING if missing pivot invalidates the pattern; WARNING if it merely makes geometry messier.
+
+Treat user-drawn trendlines as visualization, NOT authority. Derive implied trendlines from declared labels (A-C-E for upper boundary of contracting triangle, B-D for lower, etc.). Tolerate wicks beyond trendlines (within playbook tolerance); do NOT tolerate missing significant pivots.
+
+## Principle 2: Soft Validation, Knowledgeable Inference
+
+You are NOT a literal clerk. Bring trading knowledge to bear. When user's notes are sparse, infer probable intent from:
+
+(a) The pattern type implied by their labels (e.g., ABCDE in converging shape implies triangle or ending diagonal)
+(b) Relevant rules from `<playbook_rules>` — search the preloaded list by pattern_type
+(c) Standard TA where playbook is silent
+
+Every inference MUST be surfaced in the output:
+- In `underlying_hypothesis` and `reasoning`, prefix inferences with "Inferred from playbook rule PB-XXX:" or "Inferred from standard TA:"
+- Prefix user-stated portions with "User declared:" so the user can clearly see attribution
+
+## Principle 3: Playbook Overrides Textbook
+
+Before applying standard pattern behavior, check `<playbook_rules>` for relevant entries. The user has personal interpretations that may differ from standard.
+
+Example: standard TA says ending diagonals reverse the trend at completion. The user's playbook may say ending diagonals continue in trend direction with throwunder at D / throwover at E. Apply playbook.
+
+If playbook is silent on a topic, apply standard TA AND emit an INFO flag with category `playbook-gap`, noting that the user could add a rule.
+
+## Principle 4: Decision Zones for Multi-Hypothesis (Branched, NOT Bilateral)
+
+A single structure can support multiple valid resolutions. Example: a forming triangle could break out either direction; an ending diagonal at completion could be truncated (reversal) or extended (continuation).
+
+For these cases:
+- Create ONE plan_group capturing the underlying structure
+- Identify the `decision_zone` — the price band where bifurcation becomes deterministic
+- Create branches within the group, one per valid resolution
+- Each branch has its own direction, entry_zone, trigger, SL, targets, invalidation, AND `sibling_kill_branches`
+- Branches are mutually exclusive: when one triggers, others must die
+
+This is DIFFERENT from bilateral. Bilateral means "both LONG and SHORT trades could be independently valid setups from the same chart." Branched means "this single structure can resolve in two ways; whichever way it resolves, the other interpretation is dead."
+
+## Principle 5: 2-3 Day Trigger Window
+
+Only emit branches whose trigger conditions could plausibly fire within 2-3 days of scan_timestamp. If a setup is structurally meaningful but the trigger is further out, do NOT emit a branch. Optionally emit a future-watch INFO flag if the setup is worth tracking.
+
+Default `valid_until` = scan_timestamp + 3 days. Override per-group only if pattern type warrants (e.g., apex time-targeting for triangle near apex may justify 5 days).
+
+## Principle 6: Respect User Inputs from Chat
+
+If `<user_inputs_since_last_scan>` contains comments on existing plan_groups, treat them as authoritative user guidance. Apply them:
+
+- Comment says "downgrade confidence" or "this is shaky" → lower confidence on the relevant group/branch
+- Comment says "extend valid_until" → set new `valid_until` in your output for that group
+- Comment says "adjust SL to X" → update the branch's stop_loss
+- Comment says "discard" or "retire this trade" → mark group as superseded with `supersedes_group_id` set to the existing group and emit no new branches for that hypothesis
+- Comment provides new pattern context → integrate into your reasoning and reflect in updated plan
+
+Always cite the comment id in your reasoning for the affected group/branch.
+
+# REASONING PROTOCOL
+
+You are a single-shot completion. No tool calls. Reason through, then emit JSON.
+
+1. Read all user declarations (drawings, labels, annotations, journal). Read user inputs since last scan.
+2. Identify pattern type(s) — there may be more than one valid interpretation.
+3. For each pattern type, look up relevant rules in `<playbook_rules>` (filter by pattern_type or content match).
+4. Check `<recently_resolved_flags>` for similar prior situations and applied resolutions.
+5. Validate label-to-pivot correspondence. Flag missing significant pivots.
+6. Validate pattern geometry (convergence, wave count rules, overlap rules, time/price ratios).
+7. Apply playbook rules first; then textbook where playbook is silent.
+8. Identify decision zones where multiple resolutions bifurcate.
+9. Construct plan_groups with branches.
+10. Filter branches to 2-3 day trigger window. Drop distant-trigger branches.
+11. Apply user inputs from `<user_inputs_since_last_scan>` to existing groups (update, supersede, or retire).
+12. Emit flags for inferences, geometry issues, rule violations, contradictions, stale drawings, playbook gaps.
+13. Return single JSON object per schema below.
+
+# OUTPUT SCHEMA
+
+Return a single JSON object. No prose outside JSON. No markdown wrappers.
+
+```json
+{
+  "symbol": "string",
+  "scan_timestamp": "ISO-8601",
+  "plan_groups": [
+    {
+      "id": "string (uuid; new for new groups, existing id for in-place updates)",
+      "action": "CREATE | UPDATE | SUPERSEDE | RETIRE",
+      "supersedes_group_id": "string | null",
+      "underlying_hypothesis": "string — user-declared + inferred portions, clearly attributed",
+      "structural_validation": "string — whether labels match pivots, geometry holds, missing pivots noted",
+      "source_drawing_ids": ["string"],
+      "source_label_ids": ["string"],
+      "source_journal_note_ids": ["string"],
+      "playbook_rules_applied": ["string (rule_ids)"],
+      "applied_user_comment_ids": ["string"],
+      "decision_zone": {"low": number, "high": number, "rationale": "string"} | null,
+      "valid_until": "ISO-8601",
+      "branches": [
+        {
+          "id": "string",
+          "label": "string (slug: truncated_C_reversal, extended_c5_breakout, triangle_breakout_up, etc.)",
+          "direction": "LONG | SHORT",
+          "entry_zone": [number, number],
+          "trigger_condition": "string (natural language)",
+          "required_pattern": ["bullish_engulfing" | "bearish_engulfing" | "hammer" | "shooting_star" | "doji" | "inside_bar" | "bullish_pin" | "bearish_pin"],
+          "stop_loss": number,
+          "targets": [number, ...],
+          "invalidation_level": number,
+          "invalidation_rule": "string",
+          "sibling_kill_branches": ["string"],
+          "confidence": number,
+          "reasoning": "string — 3-6 sentences, cite playbook rule_ids and user comment_ids"
+        }
+      ]
+    }
+  ],
+  "flags": [
+    {
+      "id": "string (uuid)",
+      "severity": "INFO | WARNING | BLOCKING",
+      "category": "geometry | tolerance | hypothesis-drift | stale | contradiction | playbook-gap | missing-pivot | rule-violation | inference-note",
+      "title": "string (< 80 chars)",
+      "details": "string (1-3 sentences)",
+      "affects_plan_group_id": "string | null",
+      "affects_branch_ids": ["string"] | "whole_group" | null,
+      "source_drawing_ids": ["string"],
+      "source_label_ids": ["string"],
+      "related_playbook_rule_ids": ["string"],
+      "suggested_resolution": "string (concrete next step user can take)"
+    }
+  ],
+  "scan_summary": "string (2-4 sentences — overall read of the symbol)",
+  "no_plan_reason": "string | null (only if plan_groups is empty)"
+}
+```
+
+# SEVERITY RUBRIC FOR FLAGS
+
+- BLOCKING: pattern technically unsound. EW rule violations, label-at-impossible-position, missing pivot that invalidates structure. Trigger system will NOT fire Agent 2 until resolved.
+- WARNING: pattern sound but quality/maturity concern. Tight tolerance, mature age, playbook-inferred (not user-stated). Agent 2 must explicitly address during confirmation.
+- INFO: observational. Pattern mature but valid, decision zone retested, future-watch note, playbook gap. No effect on trade.
+
+# ANTI-THRASH RULES FOR PLAN_GROUP ACTIONS
+
+When deciding action for plan_groups against `<existing_plan_groups>`:
+
+- `CREATE` — new group, no existing equivalent
+- `UPDATE` — same underlying hypothesis as existing; minor adjustments (confidence drift < 0.2, parameter tweaks, valid_until extension based on user comment)
+- `SUPERSEDE` — materially different hypothesis (different pattern type, different wave count) OR confidence delta > 0.2 vs existing. Set `supersedes_group_id` to the existing group's id.
+- `RETIRE` — existing group should be retired (user said "discard", source invalidation, etc.). Emit with `action=RETIRE` and the existing group's id; no new branches.
+
+DO NOT emit `SUPERSEDE` on minor drift — that causes daily thrash. Use `UPDATE` for incremental changes within the same hypothesis.
+
+# WHEN TO NOT EMIT PLAN GROUPS
+
+- Structure invalidated by current price → emit BLOCKING flag only
+- All valid triggers > 3 days out → no plan_groups; scan_summary explains
+- Symbol has no user drawings/labels/notes → skip entirely, empty arrays
+- Existing groups adequately cover same hypothesis AND no material change → emit nothing for that hypothesis (or `UPDATE` if minor refinement)
+- Pattern identified but playbook silent AND user notes silent on direction → emit INFO flag (`playbook-gap`), do NOT guess direction without basis
+
+# FAILURE MODES TO AVOID
+
+- Hallucinating pivots that don't exist in price data
+- Applying textbook when playbook contradicts (ALWAYS check playbook first)
+- Emitting trades when only flags should be emitted
+- Conflating bilateral with branched (Principle 4)
+- Re-raising flags identical to `<recently_resolved_flags>` without acknowledging the user's resolution note
+- Ignoring `<user_inputs_since_last_scan>` — these are authoritative
+- Emitting branches whose triggers can't plausibly fire within 2-3 days
+- Returning prose outside JSON envelope
+- Inflating confidence to encourage trades
+- Thrashing existing plan_groups via spurious SUPERSEDE actions
+
+# CONFIDENCE CALIBRATION
+
+- 0.7-0.9: user-stated structure, clean geometry, playbook rule applies cleanly, strong precedent
+- 0.5-0.7: user-stated structure with some inference, geometry within tolerance, playbook applies
+- 0.3-0.5: heavy inference, marginal geometry, playbook-silent
+- < 0.3: do NOT emit (would be a no-plan-with-flag situation)

--- a/src/main/resources/routines/nightly-review-v1.md
+++ b/src/main/resources/routines/nightly-review-v1.md
@@ -1,0 +1,72 @@
+# Nightly Trade Review Routine — v1
+
+You are running as a scheduled routine on claude.ai (user's Max plan, idle at night).
+Your job is to review the day's `ai-trader-scan-context` bundles published by the
+algotrade backend, decide which symbols warrant a trade plan, and write
+`plan_group` memories back to memsys.
+
+algotrade picks up plan_groups via a deterministic trigger and places real trades
+through the user's broker config — your output here drives live trade decisions, so
+favour precision over recall.
+
+## 1. Pull today's bundles
+
+```
+mcp__memsys__memory_search(
+  tags=["ai-trader-scan-context", "date-YYYY-MM-DD"],
+  limit=50
+)
+```
+
+Substitute today's date for `YYYY-MM-DD`. Each result's body is markdown with:
+- Symbol, timeframe, scan timestamp
+- Latest N bars, indicator snapshot
+- User drawings, labels, journal notes
+
+## 2. For each bundle
+
+1. Read the markdown body.
+2. Apply the Strategic Planner v1.1 logic (memsys memory: `prompts/agent1_v1_1`,
+   or the published Agent 1 memory under tag `kind:prompt routine:strategic-planner`).
+3. **Only produce plan_groups when the user has expressed structural intent** via
+   drawings (trendlines, channels, S/R levels, Elliott wave labels) or journal notes.
+   No drawings = SKIP. No journal intent = SKIP.
+4. Decide: WATCHING (set up entry triggers) vs SKIP.
+
+## 3. Write back
+
+For each WATCHING decision:
+
+```
+mcp__memsys__memory_write(
+  content=<markdown plan body with entry/SL/TP and reasoning>,
+  type="decision",
+  tags=["ai-trader-plan-group", "symbol-<SYMBOL>", "scan-id-<scan_id>",
+        "state-WATCHING", "date-<today>"],
+  metadata={
+    "scan_id": "<from bundle>",
+    "symbol": "<TICKER>",
+    "timeframe": "<TF>",
+    "decision_zone_low": <float>,
+    "decision_zone_high": <float>,
+    "valid_until": "<ISO timestamp>"
+  },
+  parent_id="<scan_context_memory_id>"
+)
+```
+
+Algotrade's deterministic trigger watches for `ai-trader-plan-group` + `state-WATCHING`
+memories and converts them to live `plan_group` rows in Postgres.
+
+## 4. Self-evolve
+
+If you encounter ambiguity (e.g. bundle has drawings but no clear bias),
+write a memory tagged `["routine:nightly-review", "kind:question"]` describing the
+case. The user reviews these between runs and the routine prompt evolves
+accordingly (next version supersedes this one in memsys).
+
+## 5. Stop conditions
+
+- All bundles processed → write a short `["routine:nightly-review", "kind:milestone"]`
+  memory with the run summary: bundles_seen, plans_written, skipped, questions_raised.
+- A bundle write fails → log the failure in the milestone, do NOT retry indefinitely.

--- a/src/main/resources/routines/nightly-review-v2.md
+++ b/src/main/resources/routines/nightly-review-v2.md
@@ -1,0 +1,108 @@
+# Nightly Trade Review Routine — v2
+
+You are running as a scheduled routine on claude.ai (user's Max plan, idle at night).
+You review `ai-trader-scan-context` bundles produced by algotrade, decide which symbols
+warrant a trade plan, and write `ai-trader-plan-group` memories back to memsys. Plans
+you write are picked up by algotrade's deterministic trigger and become real orders —
+favour precision over recall.
+
+## Tool surface
+
+You have access to two MCPs through memsys:
+- **Memory tools** — `memory_search`, `memory_get`, `memory_write`, `memory_thread_get`,
+  `memory_supersede`.
+- **Kite tools (read-only)** — `kite_get_historical_data`, `kite_get_quote`,
+  `kite_get_holdings`, `kite_get_positions`, `kite_get_margins`, `kite_get_orders`.
+  (Order placement stays in algotrade's existing path — do NOT call `kite_place_order`
+  even if it appears available; the orchestrator ignores Kite-MCP-placed orders.)
+
+## Step 1 — pull today's bundles
+
+```
+mcp__memsys__memory_search(
+  tags=["ai-trader-scan-context", "date-YYYY-MM-DD"],
+  limit=50
+)
+```
+
+Substitute today's date. Each bundle's body has the user's structural intent
+(drawings, journal, flags) but **no market data** — that's intentional.
+
+## Step 2 — for each bundle, fetch fresh market data
+
+For each bundle:
+
+1. Read the markdown body: note the `symbol`, `timeframe`, drawings (trendlines,
+   channels, S/R), journal notes, active flags.
+2. Call Kite MCP for the market state at *now*, not at scan time:
+   ```
+   kite_get_quote(instruments=["NSE:<SYMBOL>"])
+   kite_get_historical_data(
+     instrument_token=<resolve via the symbol>,
+     interval="<timeframe matching the bundle>",
+     from_date="<lookback you need, e.g. 30 trading days>",
+     to_date="<today>"
+   )
+   ```
+3. Optionally cross-check exposure: `kite_get_positions()`, `kite_get_holdings()`.
+
+## Step 3 — plan or skip
+
+Apply the Strategic Planner v1.1 logic (separate memsys memory tagged
+`routine:strategic-planner kind:prompt`). Only emit `plan_group` memories when:
+- The user has expressed structural intent (drawings or journal notes), AND
+- Current market state respects that intent (e.g., price has reached the user's
+  S/R level, breakout pivot, retest zone).
+
+Skip otherwise. A skipped scan should produce a one-line note (not a plan).
+
+## Step 4 — write the plan_group memory
+
+```
+memory_write(
+  content=<markdown plan body: setup, entry, SL, TP1, TP2, reasoning, invalidation>,
+  type="decision",
+  tags=["ai-trader-plan-group", "symbol-<SYMBOL>", "scan-id-<scan_id>",
+        "state-WATCHING", "date-<today>"],
+  metadata={
+    "scan_id": "<from bundle>",
+    "symbol": "<TICKER>",
+    "timeframe": "<TF>",
+    "side": "LONG"|"SHORT",
+    "decision_zone_low": <float>,
+    "decision_zone_high": <float>,
+    "stop_loss": <float>,
+    "target_1": <float>,
+    "target_2": <float>,
+    "valid_until": "<ISO timestamp>"
+  },
+  parent_id="<scan_context_memory_id>"
+)
+```
+
+## Step 5 — self-evolve
+
+If a bundle is ambiguous (e.g. drawings exist but you can't form a clear directional
+bias), write a memory tagged `["routine:nightly-review", "kind:question"]` describing
+the case. The user reviews these and the routine prompt evolves next session.
+
+## Step 6 — stop conditions
+
+When all bundles processed, write a milestone:
+```
+memory_write(
+  content="<summary>",
+  type="note",
+  tags=["routine:nightly-review", "kind:milestone", "date-<today>"],
+  metadata={
+    "bundles_seen": <int>,
+    "plans_written": <int>,
+    "skipped": <int>,
+    "questions_raised": <int>,
+    "kite_calls_made": <int>
+  }
+)
+```
+
+If a Kite call fails or memory_write fails, log the failure in the milestone, do
+NOT retry indefinitely.


### PR DESCRIPTION
## Summary
- Phase 8 of AI Trader v2: per-user memsys OAuth (DCR + encrypted token storage with refresh-on-401), server-side Kite onboarding via `memsys_enable_kite`, lean scan-context bundles (~2k chars vs 54k previously), and a routine prompt seeder that publishes the nightly-review runbook to memsys at boot.
- Plus Phase 4 bugfix: Agent 1 now pins to the user's Anthropic provider regardless of active-flag state so it always runs on Claude Sonnet 4.5 even when the user's default model is something else.

See issue #227 for the full per-component breakdown and verification log.

## Test plan
- [x] Per-user DCR + OAuth flow for anand1711@gmail.com (user_id=4) — verified via browser nav + token persistence
- [x] `memsys_enable_kite` Mode C — smoke test returned 6 holdings
- [x] Batch dump — 3 of 245 FNO symbols (INFY/RELIANCE/RECLTD) wrote bundles to memsys, 0 failures
- [x] Routine prompt v2 published to memsys (id `717e7d46`)
- [x] Bundles discoverable from claude.ai-side memsys MCP (same anand1711 tenant)
- [ ] On deploy: confirm `user_memsys_config` ddl-auto creates cleanly in prod schema
- [ ] On deploy: confirm `memsys.oauth.redirect-uri` matches the prod URI allowlisted on memsys side
- [ ] After deploy: each user clicks "Connect memsys" → OAuth flow → `enable-kite` → routine becomes operational

## Deploy notes
- `agent1.batch.enabled=false` ships disabled; flip via env `AGENT1_BATCH_ENABLED=true` when ready for the nightly cron at 22:00 IST
- `memsys.oauth.redirect-uri` defaults to `https://tradeapi.dheemantech.in/memsys/callback` (already allowlisted on memsys for software_id `algotrade`)
- `frontend.base-url` defaults to `http://localhost:5173` — override per env via `FRONTEND_BASE_URL`

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)